### PR TITLE
fix errors in concepts/values

### DIFF
--- a/docs/concepts/values.md
+++ b/docs/concepts/values.md
@@ -58,6 +58,7 @@ JavaScript `Number` type with Rust Int/Float types: `u32`, `i32`, `i64`, `f64`.
 For Rust types like `u64`, `u128`, `i128`, checkout [`BigInt`](#bigint) section.
 
 ```rust title=lib.rs
+#[napi]
 fn sum(a: u32, b: i32) -> i64 {
 	(b + a as i32).into()
 }
@@ -106,7 +107,7 @@ fn with_buffer(buf: Buffer) {
 	// do something
 }
 
-fn read_buffer(file: String): Buffer {
+fn read_buffer(file: String) -> Buffer {
 	Buffer::from(std::fs::read(file).unwrap())
 }
 ```

--- a/docs/concepts/values.md
+++ b/docs/concepts/values.md
@@ -12,7 +12,7 @@ Represent `undefined` in JavaScript.
 ```rust {3} title=lib.rs
 #[napi]
 fn get_undefined() -> Undefined {
-	Undefined
+	()
 }
 
 // default return or empty tuple `()` are `undefined` after converted into JS value.


### PR DESCRIPTION
There were a few compile errors, typos, and incorrect TS outputs, so I tried to fix them.

These don't seem to compile either, not sure how to fix them:
https://github.com/napi-rs/website/blob/eab36519b218132566c507385fc47263bcad74ae/docs/concepts/values.md#L103-L107
```
error[E0277]: the trait bound `Vec<u8>: From<napi::bindgen_prelude::Buffer>` is not satisfied
   --> src/lib.rs:9:13
    |
9   |   let buf = Vec::<u8>::from(buf);
    |             ^^^^^^^^^^^^^^^ the trait `From<napi::bindgen_prelude::Buffer>` is not implemented for `Vec<u8>`
    |
    = help: the following implementations were found:
              <Vec<T, A> as From<Box<[T], A>>>
              <Vec<T, A> as From<VecDeque<T, A>>>
              <Vec<T> as From<&[T]>>
              <Vec<T> as From<&mut [T]>>
            and 9 others
note: required by `from`
```

https://github.com/napi-rs/website/blob/eab36519b218132566c507385fc47263bcad74ae/docs/concepts/values.md#L135-L138