### PR TITLE
fix various errors in docs/concepts/*

### DIFF
--- a/docs/concepts/async-fn.md
+++ b/docs/concepts/async-fn.md
@@ -3,9 +3,9 @@ title: 'async fn'
 description: Running Rust async fn with tokio runtime.
 ---
 
-You can do a lot of async/multi-thread stuffs with `AsyncTask` and `ThreadsafeFunction`, but sometimes you may want to use the crates from Rust async ecosystem directly.
+You can do a lot of async/multi-threaded work with `AsyncTask` and `ThreadsafeFunction`, but sometimes you may want to use the crates from the Rust async ecosystem directly.
 
-**NAPI-RS** support the `tokio` runtime by default. If you `await` a tokio `future` in `async fn`, **NAPI-RS** will execute it in the tokio runtime and convert it into a JavaScript `Promise`.
+**NAPI-RS** supports the `tokio` runtime by default. If you `await` a tokio `future` in `async fn`, **NAPI-RS** will execute it in the tokio runtime and convert it into a JavaScript `Promise`.
 
 ```rust {6} title=lib.rs
 use futures::prelude::*;

--- a/docs/concepts/async-fn.md
+++ b/docs/concepts/async-fn.md
@@ -1,6 +1,6 @@
 ---
 title: 'async fn'
-description: Run a Rust async fn with tokio runtime.
+description: Run a Rust async fn with the tokio runtime.
 ---
 
 You can do a lot of async/multi-threaded work with `AsyncTask` and `ThreadsafeFunction`, but sometimes you may want to use the crates from the Rust async ecosystem directly.

--- a/docs/concepts/async-fn.md
+++ b/docs/concepts/async-fn.md
@@ -1,6 +1,6 @@
 ---
 title: 'async fn'
-description: Running Rust async fn with tokio runtime.
+description: Run a Rust async fn with tokio runtime.
 ---
 
 You can do a lot of async/multi-threaded work with `AsyncTask` and `ThreadsafeFunction`, but sometimes you may want to use the crates from the Rust async ecosystem directly.

--- a/docs/concepts/async-task.md
+++ b/docs/concepts/async-task.md
@@ -1,6 +1,6 @@
 ---
 title: 'AsyncTask'
-description: Run task in libuv thread pool and abort it with AbortSignal.
+description: Run a task in the libuv thread pool and abort it with AbortSignal.
 ---
 
 We need to talk about `Task` before talking about `AsyncTask`.

--- a/docs/concepts/async-task.md
+++ b/docs/concepts/async-task.md
@@ -1,15 +1,15 @@
 ---
 title: 'AsyncTask'
-description: Running task in libuv thread pool and abort it with AbortSignal.
+description: Run task in libuv thread pool and abort it with AbortSignal.
 ---
 
 We need to talk about `Task` before talking about `AsyncTask`.
 
 ## `Task`
 
-Addon modules often need to leverage async helpers from libuv as part of their implementation. This allows them to schedule work to be executed asynchronously so that their methods can return in advance of the work being completed. This allows them to avoid blocking overall execution of the Node.js application.
+Addon modules often need to leverage async helpers from libuv as part of their implementation. This allows them to schedule work to be executed asynchronously so that their methods can return in advance of the work being completed. This allows them to avoid blocking the overall execution of the Node.js application.
 
-The `Task` trait provide a way to define such asynchronous task need to run in the libuv thread. You can implement the `compute` method, which will be called in the libuv thread.
+The `Task` trait provides a way to define such an asynchronous task that needs to run in the libuv thread. You can implement the `compute` method, which will be called in the libuv thread.
 
 ```rust {11-13} title=lib.rs
 use napi::{Task, Env, Result, JsNumber};
@@ -27,22 +27,22 @@ impl Task for AsyncFib {
   }
 
   fn resolve(&mut self, env: Env, output: u32) -> Result<Self::JsValue> {
-    enc.create_uint32(output)
+    env.create_uint32(output)
   }
 }
 ```
 
-The `fn compute` below happened on the libuv thread, you can run some heavy computation here, which will not block the main JavaScript thread.
+`fn compute` ran on the libuv thread, you can run some heavy computation here, which will not block the main JavaScript thread.
 
-You may notice there are two associate types on the `Task` trait. The `type Output` and the `type JsValue`. The `Output` is the return type of the `compute` method. The `JsValue` is the return type of the `resolve` method.
+You may notice there are two associate types on the `Task` trait. The `type Output` and the `type JsValue`. `Output` is the return type of the `compute` method. `JsValue` is the return type of the `resolve` method.
 
 :::info
-We need separated `type Output` and `type JsValue` is because we can not call the JavaScript function back in the `fn compute`, it is not executed on the main thread. So we need the `fn resolve` which is running on the main thread to create the `JsValue` from `Output` and `Env` and call it back to the JavaScript.
+We need separate `type Output` and `type JsValue` because we can not call the JavaScript function back in `fn compute`, it is not executed on the main thread. So we need `fn resolve`, which runs on the main thread, to create the `JsValue` from `Output` and `Env` and call it back in JavaScript.
 :::
 
-You can use the low-level API: `Env::spawn` to spawn a defined `Task` into libuv thread pool. See example in [Reference](../compat-mode/concepts/ref).
+You can use the low-level API `Env::spawn` to spawn a defined `Task` in the libuv thread pool. See example in [Reference](../compat-mode/concepts/ref).
 
-Expect `compute` and `resolve`, you can also provide `reject` method to do some clean up when `Task` ran into error, like `unref` some object:
+In addition to `compute` and `resolve`, you can also provide `reject` method to do some clean up when `Task` runs into error, like `unref` some object:
 
 ```rust {28} title=lib.rs
 struct CountBufferLength {
@@ -66,12 +66,12 @@ impl Task for CountBufferLength {
     Ok((&self.data).len())
   }
 
-  fn resolve(self, env: Env, output: Self::Output) -> Result<Self::JsValue> {
+  fn resolve(&mut self, env: Env, output: Self::Output) -> Result<Self::JsValue> {
     self.data.unref(env)?;
     env.create_uint32(output as _)
   }
 
-  fn reject(self, env: Env, err: Error) -> Result<Self::JsValue> {
+  fn reject(&mut self, env: Env, err: Error) -> Result<Self::JsValue> {
     self.data.unref(env)?;
     Err(err)
   }
@@ -107,19 +107,20 @@ impl Task for CountBufferLength {
     env.create_uint32(output as _)
   }
 
-  fn finally(&mut self, env: Env, err: Error) -> Result<()> {
+  fn finally(&mut self, env: Env) -> Result<()> {
     self.data.unref(env)?;
+    Ok(())
   }
 }
 ```
 
 :::info
-The `#[napi]` macro below the `impl Task for AsyncFib` is just for `.d.ts` generation. If no `#[napi]` defined here, the generated TypeScript type of returned `AsyncTask` will be `Promise<unknown>`.
+The `#[napi]` macro above the `impl Task for AsyncFib` is just for `.d.ts` generation. If no `#[napi]` is defined here, the generated TypeScript type of returned `AsyncTask` will be `Promise<unknown>`.
 :::
 
 ## `AsyncTask`
 
-The `Task` you defined can not return to the `JavaScript` directly, `JavaScript` engine has no idea how to run and resolve value from your `struct`. `AsyncTask` is a wrapper of `Task` which can return to the `JavaScript` engine. It could be created with `Task` and a optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal).
+The `Task` you defined cannot be returned to JavaScript directly, the JavaScript engine has no idea how to run and resolve the value from your `struct`. `AsyncTask` is a wrapper of `Task` which can return to the JavaScript engine. It can created with `Task` and an optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal).
 
 ```rust title=lib.rs
 #[napi]
@@ -136,7 +137,7 @@ export function asyncFib(input: number) => Promise<number>
 
 ### Create `AsyncTask` With `AbortSignal`
 
-In some scenario, you may want to abort the queued `AsyncTask`, like using `debounce` on some compute tasks. You can also provide the `AbortSignal` to `AsyncTask`, so that you can abort the `AsyncTask` if it has not been started.
+In some scenarios, you may want to abort the queued `AsyncTask`, for example, using `debounce` on some compute tasks. You can provide `AbortSignal` to `AsyncTask`, so that you can abort the `AsyncTask` if it has not been started.
 
 ```rust {4} title=lib.rs
 use napi::bindgen_prelude::AbortSignal;
@@ -153,7 +154,7 @@ fn async_fib(input: u32, signal: AbortSignal) -> AsyncTask<AsyncFib> {
 export function asyncFib(input: number, signal: AbortSignal) => Promise<number>
 ```
 
-If you invoke `AbortController.abort` in the JavaScript and the `AsyncTask` is not started yet, the `AsyncTask` will be aborted immediately, and reject an `AbortError`.
+If you invoke `AbortController.abort` in the JavaScript code and the `AsyncTask` has not been started yet, the `AsyncTask` will be aborted immediately, and reject with `AbortError`.
 
 ```js {6} title=test.mjs
 import { asyncFib } from './index.js'
@@ -167,7 +168,7 @@ asyncFib(20, controller.signal).catch((e) => {
 controller.abort()
 ```
 
-You can also provide the `Option<AbortSignal>` to `AsyncTask` if you don't know if the `AsyncTask` need to be aborted:
+You can also provide `Option<AbortSignal>` to `AsyncTask` if you don't know if the `AsyncTask` needs to be aborted:
 
 ```rust title=lib.rs
 use napi::bindgen_prelude::AbortSignal;
@@ -181,9 +182,12 @@ fn async_fib(input: u32, signal: Option<AbortSignal>) -> AsyncTask<AsyncFib> {
 ⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️
 
 ```ts title=index.d.ts
-export function asyncFib(input: number, signal?: AbortSignal | null) => Promise<number>
+export function asyncFib(
+  input: number,
+  signal?: AbortSignal | undefined | null,
+): Promise<number>
 ```
 
 :::info
-If `AsyncTask` is already started or completed, the `AbortController.abort` will have no effect.
+If `AsyncTask` has already been started or completed, the `AbortController.abort` will have no effect.
 :::

--- a/docs/concepts/await-promise.md
+++ b/docs/concepts/await-promise.md
@@ -1,6 +1,6 @@
 ---
 title: 'Await Promise'
-description: Await JavaScript Promise in the Rust.
+description: Await a JavaScript Promise in Rust.
 ---
 
 Awaiting a JavaScript `Promise` in Rust sounds crazy, but it's feasible in **NAPI-RS**.

--- a/docs/concepts/await-promise.md
+++ b/docs/concepts/await-promise.md
@@ -3,10 +3,10 @@ title: 'Await Promise'
 description: Await JavaScript Promise in the Rust.
 ---
 
-Await JavaScript `Promise` in the Rust sounds crazy, but it's feasible in **NAPI-RS**.
+Awaiting a JavaScript `Promise` in Rust sounds crazy, but it's feasible in **NAPI-RS**.
 
 :::caution
-await JavaScript `Promise` need the `tokio_rt` and `napi4` features to be enabled.
+Awaiting a JavaScript `Promise` needs the `tokio_rt` and `napi4` features to be enabled.
 :::
 
 ```rust title=lib.rs

--- a/docs/concepts/class.md
+++ b/docs/concepts/class.md
@@ -3,14 +3,14 @@ title: 'Class'
 ---
 
 :::info
-There is no concept of a class in Rust. We decide to use the `struct` to represent a JavaScript `Class`.
+There is no concept of a class in Rust. We use `struct` to represent a JavaScript `Class`.
 :::
 
 ## `Constructor`
 
 ### Default `constructor`
 
-If a all fields in a `Rust` struct is `pub`, then you can use `#[napi(constructor)]` to make the `struct` have a default `constructor`.
+If all fields in a `Rust` struct are `pub`, then you can use `#[napi(constructor)]` to make the `struct` have a default `constructor`.
 
 ```rust title=lib.rs
 #[napi(constructor)]
@@ -30,11 +30,10 @@ export class AnimalWithDefaultConstructor {
 
 ### Custom `constructor`
 
-If you want to define a custom `constructor`, you can specified on of the `fn` in struct `impl` block as your custom constructor by using `#[napi(constructor)]`.
+If you want to define a custom `constructor`, you can use `#[napi(constructor)]` on your constructor `fn` in the struct `impl` block.
 
 ```rust title=lib.rs
-
-// A complexity struct which can not be exposed into JavaScript directly.
+// A complex struct which cannot be exposed to JavaScript directly.
 struct QueryEngine {}
 
 #[napi(js_name = "QueryEngine")]
@@ -58,7 +57,7 @@ export class QueryEngine {
 ```
 
 :::caution
-**NAPI-RS** now is not support `private constructor`. Your custom constructor must be `pub` in Rust.
+**NAPI-RS** does not currently support `private constructor`. Your custom constructor must be `pub` in Rust.
 :::
 
 ## Factory
@@ -66,7 +65,7 @@ export class QueryEngine {
 Besides `constructor`, you can also define factory methods on `Class` by using `#[napi(factory)]`.
 
 ```rust title=lib.rs
-// A complexity struct which can not be exposed into JavaScript directly.
+// A complex struct which cannot be exposed to JavaScript directly.
 struct QueryEngine {}
 
 #[napi(js_name = "QueryEngine")]
@@ -91,21 +90,21 @@ export class QueryEngine {
 ```
 
 :::caution
-If no `#[napi(constructor)]` defined in `struct`, and `new` the `Class` in JavaScript. An error will be thrown.
+If no `#[napi(constructor)]` is defined in the `struct`, and you attempt to create an instance (`new`) of the `Class` in JavaScript, an error will be thrown.
 :::
 
 ```js {3} title=test.mjs
 import { QueryEngine } from './index.js'
 
-new QueryEngine() // Error: Class contains no `constructor`, can not new it!
+new QueryEngine() // Error: Class contains no `constructor`, cannot create it!
 ```
 
 ## `class method`
 
-You can define a JavaScript class method with `#[napi]` on a struct `method` in **Rust**.
+You can define a JavaScript class method with `#[napi]` on a struct method in **Rust**.
 
 ```rust title=lib.rs
-// A complexity struct which can not be exposed into JavaScript directly.
+// A complex struct which cannot be exposed to JavaScript directly.
 struct QueryEngine {}
 
 #[napi(js_name = "QueryEngine")]
@@ -143,19 +142,19 @@ export class QueryEngine {
 ```
 
 :::caution
-`async fn` need `napi4` and `tokio_rt` features to be enabled.
+`async fn` needs the `napi4` and `tokio_rt` features to be enabled.
 :::
 
 :::info
-Any fn in `Rust` return `Result<T>` will be treated as `T` in JavaScript/TypeScript. If the `Result<T>` is `Err`, an JavaScript Error will be thrown.
+Any `fn` in `Rust` that returns `Result<T>` will be treated as `T` in JavaScript/TypeScript. If the `Result<T>` is `Err`, a JavaScript Error will be thrown.
 :::
 
 ## `Getter`
 
-Define [JavaScript class `getter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get) using `#[napi(getter)]`. The Rust fn must be struct methods, not associated function.
+Define [JavaScript class `getter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get) using `#[napi(getter)]`. The Rust `fn` must be a struct method, not an associated function.
 
 ```rust {22-25} title=lib.rs
-// A complexity struct which can not be exposed into JavaScript directly.
+// A complex struct which cannot be exposed to JavaScript directly.
 struct QueryEngine {}
 
 #[napi(js_name = "QueryEngine")]
@@ -193,10 +192,10 @@ export class QueryEngine {
 
 ## `Setter`
 
-Define [JavaScript class `setter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set) using `#[napi(setter)]`. The Rust fn must be struct methods, not associated function.
+Define [JavaScript class `setter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set) using `#[napi(setter)]`. The Rust `fn` must be a struct method, not an associated function.
 
 ```rust {27-30} title=lib.rs
-// A complexity struct which can not be exposed into JavaScript directly.
+// A complex struct which cannot be exposed to JavaScript directly.
 struct QueryEngine {}
 
 #[napi(js_name = "QueryEngine")]
@@ -240,9 +239,9 @@ export class QueryEngine {
 
 ## Class as argument
 
-`Class` is different between [`Object`](./object). `Class` could have Rust methods, associated functions on it. Every field in `Class` could be mutated in JavaScript.
+`Class` is different from [`Object`](./object). `Class` can have Rust methods and associated functions on it. Every field in `Class` can mutated in JavaScript.
 
-So the ownership of the `Class` is actually transferred to the JavaScript side while you are creating it. It is managed by JavaScript GC, and the only way you can pass it back is pass the `reference` of it.
+So the ownership of the `Class` is actually transferred to the JavaScript side while you are creating it. It is managed by the JavaScript GC, and you can only pass it back by passing its `reference`.
 
 ```rust title=lib.rs
 fn accept_class(engine: &QueryEngine) {

--- a/docs/concepts/enum.md
+++ b/docs/concepts/enum.md
@@ -6,7 +6,7 @@ title: 'Enum'
 There is no `enum` in JavaScript, and Rust `enum` is very different from TypeScript `enum`. You need read this section carefully before you use Rust `enum` in JavaScript.
 :::
 
-In **NAPI-RS**, Rust `enum` is basically transform into a plain JavaScript Object.
+In **NAPI-RS**, Rust `enum` is basically transformed into a plain JavaScript Object.
 
 ```rust title=lib.rs
 #[napi]
@@ -27,6 +27,6 @@ export const enum Kind {
 }
 ```
 
-In `TypeScript`, numeric `enums` members also get a reverse mapping from enum values to enum names. But in Rust, we don't have this reverse mapping behavior. It just a plain JavaScript Object.
+In `TypeScript`, numeric `enums` members also get a reverse mapping from enum values to enum names. But in Rust, we don't have this reverse mapping behavior. It is just a plain JavaScript Object.
 
-Also, **NAPI-RS** doesn't support generate Rust `enum` `impl` into JavaScript.
+Also, **NAPI-RS** doesn't support generating Rust `enum` `impl` into JavaScript.

--- a/docs/concepts/exports.md
+++ b/docs/concepts/exports.md
@@ -3,15 +3,15 @@ title: 'Exports'
 ---
 
 :::info
-Unlike defining modules in `Node.js`, we don't need to explicitly register exports like `module.exports.xxx = xxx`.
+Unlike defining modules in Node.js, we don't need to explicitly register exports like `module.exports.xxx = xxx`.
 
-`#[napi]` macro will automatically generate module registering code for you.
-The auto registering idea inspired by [node-bindgen](https://github.com/infinyon/node-bindgen)
+The `#[napi]` macro will automatically generate module registering code for you.
+This auto registering idea was inspired by [node-bindgen](https://github.com/infinyon/node-bindgen).
 :::
 
 ### `Function`
 
-exports a function is incredibly simple. What you should do is just decorate a normal rust function with `#[napi]` macro:
+EXporting a function is incredibly simple. Just decorate a normal rust function with `#[napi]`:
 
 ```rust title=lib.rs
 #[napi]
@@ -38,8 +38,8 @@ See [`class section`](./class) for more details.
 ```rust title=lib.rs
 #[napi(constructor)]
 struct Animal {
-  pub name: String
-  pub kind: u32
+  pub name: String,
+  pub kind: u32,
 }
 
 #[napi]

--- a/docs/concepts/external.md
+++ b/docs/concepts/external.md
@@ -1,6 +1,6 @@
 ---
 title: 'External'
-description: External Object holds the native value with a JavaScript Object.
+description: External Object holds the native value in a JavaScript Object.
 ---
 
 [`External`](https://nodejs.org/api/n-api.html#napi_create_external) is very similar to [`Object Wrap`](https://nodejs.org/api/n-api.html#object-wrap), which is used in [Class](./class) under the hood.

--- a/docs/concepts/external.md
+++ b/docs/concepts/external.md
@@ -5,7 +5,7 @@ description: External Object holds the native value with a JavaScript Object.
 
 [`External`](https://nodejs.org/api/n-api.html#napi_create_external) is very similar to [`Object Wrap`](https://nodejs.org/api/n-api.html#object-wrap), which is used in [Class](./class) under the hood.
 
-The `Object Wrap` is attach a Native value to a existed JavaScript Object, and you can get a notify when the attached JavaScript Object is recycled by GC. The `External` is create an empty blank JavaScript Object which hold the native value under the hood. The only way it works is to pass back to the Rust:
+`Object Wrap` attaches a native value to a JavaScript Object and can notify you when the attached JavaScript Object is recycled by GC. `External` creates an empty, blank JavaScript Object which holds the native value under the hood. It only works by passing the object back to Rust:
 
 ```rust title=lib.rs
 use napi::bindgen_prelude::*;
@@ -30,7 +30,7 @@ export class ExternalObject<T> {
 export function createSourceMap(length: number): ExternalObject<Buffer>
 ```
 
-The `External` is very useful when you want return a JavaScript Object with some methods on it to interact with the native Rust code.
+`External` is very useful when you want to return a JavaScript Object with some methods on it to interact with the native Rust code.
 
 Here is an real world example:
 
@@ -63,7 +63,7 @@ impl MagicString {
 }
 ```
 
-First the `generate_map` method return an `External` object, and then the `JavaScript` function hold the `External` object in closure:
+First the `generate_map` method returns an `External` object, and then the JavaScript function holds the `External` object in closure:
 
 ```ts title=index.js
 module.exports.MagicString = class MagicString extends MagicStringNative {

--- a/docs/concepts/function.md
+++ b/docs/concepts/function.md
@@ -11,7 +11,7 @@ fn sum(a: u32, b: u32) -> u32 {
 }
 ```
 
-The most important thing you should keep in mind is **_NAPI-RS fn can not take every kind of type in Rust_**. Here is a table to illustrate how JavaScript types map with Rust types when they are `fn` arguments and return type:
+The most important thing you should keep in mind is **_NAPI-RS fn can not take every kind of type in Rust_**. Here is a table to illustrate how JavaScript types map to Rust types when they are `fn` arguments and return types:
 
 ## Arguments
 

--- a/docs/concepts/function.md
+++ b/docs/concepts/function.md
@@ -2,7 +2,7 @@
 title: 'Function'
 ---
 
-Define JavaScript `function` is very simple in **NAPI-RS**. Just a plain Rust `fn`:
+Defining a JavaScript `function` is very simple in **NAPI-RS**. Just a plain Rust `fn`:
 
 ```rust title=lib.rs
 #[napi]
@@ -11,7 +11,7 @@ fn sum(a: u32, b: u32) -> u32 {
 }
 ```
 
-The most important thing you should keep in mind is **_NAPI-RS fn can not take every kind of type in Rust_**. Here is a table to illustrate how JavaScript mapping with Rust type when they are `fn` arguments and return type:
+The most important thing you should keep in mind is **_NAPI-RS fn can not take every kind of type in Rust_**. Here is a table to illustrate how JavaScript types map with Rust types when they are `fn` arguments and return type:
 
 ## Arguments
 

--- a/docs/concepts/inject-env.md
+++ b/docs/concepts/inject-env.md
@@ -3,9 +3,9 @@ title: 'Inject Env'
 description: 'Inject Node-API Env into functions and methods'
 ---
 
-`#[napi]` macro is a very high level abstraction for the `Node-API`. You are mostly play with the Rust native API and crates.
+The `#[napi]` macro is a very high level abstraction for the `Node-API`. Most of the time, you use the Rust native API and crates.
 
-But sometimes you still need to access the low-level `Node-API`, for example, to call the [`napi_async_cleanup_hook`](https://nodejs.org/api/n-api.html#napi_async_cleanup_hook) or the [`napi_adjust_external_memory`](https://nodejs.org/api/n-api.html#napi_adjust_external_memory).
+But sometimes you still need to access the low-level `Node-API`, for example, to call [`napi_async_cleanup_hook`](https://nodejs.org/api/n-api.html#napi_async_cleanup_hook) or [`napi_adjust_external_memory`](https://nodejs.org/api/n-api.html#napi_adjust_external_memory).
 
 For this scenario, **NAPI-RS** allow you to inject `Env` into your `fn` which is decorated by the `#[napi]`.
 
@@ -19,7 +19,7 @@ fn call_env(env: Env, length: u32) -> Result<External<Vec<u32>>> {
 }
 ```
 
-And the `Env` will be auto injected by **NAPI-RS**, it does not effect the `arguments` types in the JavaScript side:
+And the `Env` will be auto injected by **NAPI-RS**, it does not affect the `arguments` types in the JavaScript side:
 
 ```ts title=index.d.ts
 export function callEnv(length: number) -> ExternalObject<number[]>
@@ -28,7 +28,7 @@ export function callEnv(length: number) -> ExternalObject<number[]>
 You can also inject `Env` in `impl` block:
 
 ```rust {18} title=lib.rs
-// A complexity struct which can not be exposed into JavaScript directly.
+// A complex struct which can not be exposed into JavaScript directly.
 struct QueryEngine {}
 
 #[napi(js_name = "QueryEngine")]

--- a/docs/concepts/inject-env.md
+++ b/docs/concepts/inject-env.md
@@ -1,6 +1,6 @@
 ---
 title: 'Inject Env'
-description: 'Inject Node-API Env into functions and methods'
+description: Inject Node-API Env into functions and methods.
 ---
 
 The `#[napi]` macro is a very high level abstraction for the `Node-API`. Most of the time, you use the Rust native API and crates.

--- a/docs/concepts/naming-conventions.md
+++ b/docs/concepts/naming-conventions.md
@@ -4,7 +4,7 @@ title: 'Naming conventions'
 
 ## `snake_case` to `camelCase`
 
-The code styles is very different between Rust and JavaScript. The Rust community is prefer the `snake_case` style variable while the JavaScript community is prefer the `camelCase` style. **NAPI-RS** will change the case of the Rust code to the `camelCase` style automatically.
+The code styles are very different between Rust and JavaScript. The Rust community prefers the `snake_case` style while the JavaScript community prefers the `camelCase` style. **NAPI-RS** will change the case of the Rust code to the `camelCase` style automatically.
 
 ```rust title=lib.rs
 #[napi]
@@ -19,12 +19,12 @@ fn a_function(a_arg: u32) -> u32 {
 export function aFunction(aArg: number): number
 ```
 
-## `js_rename`
+## `js_name`
 
-You can use the `js_rename` directive in `#[napi]` attribute to rename the JavaScript function.
+You can use the `js_name` attribute in `#[napi]` to rename the JavaScript function.
 
 ```rust {1} title=lib.rs
-#[napi(js_rename = "coolFunction")]
+#[napi(js_name = "coolFunction")]
 fn a_function(a_arg: u32) -> u32 {
   a_arg + 1
 }

--- a/docs/concepts/object.md
+++ b/docs/concepts/object.md
@@ -15,10 +15,10 @@ pub struct Pet {
 Any `impl` block of this `struct` will not affect the JavaScript `Object`.
 
 :::caution
-If you want a convert Rust `struct` into JavaScript `Object` using `#[napi(object)]` attribute, you need to mark all of its fields as `pub`.
+If you want to convert a Rust `struct` into JavaScript `Object` using `#[napi(object)]` attribute, you need to mark all of its fields as `pub`.
 :::
 
-Once `struct` is marked as `#[napi(object)]`, you can use it as function arguments type or return type.
+Once `struct` is marked as `#[napi(object)]`, you can use it as a function argument type or return type.
 
 ```rust title=lib.rs
 #[napi(object)]

--- a/docs/concepts/object.md
+++ b/docs/concepts/object.md
@@ -12,13 +12,13 @@ pub struct Pet {
 }
 ```
 
-Any `impl` block of this `struct` will not affect to the JavaScript `Object`.
+Any `impl` block of this `struct` will not affect the JavaScript `Object`.
 
 :::caution
-If you want a convert Rust `struct` into JavaScript `Object` using `#[napi(object)]` attribute, you need to mark all of the fields of it as `pub`.
+If you want a convert Rust `struct` into JavaScript `Object` using `#[napi(object)]` attribute, you need to mark all of its fields as `pub`.
 :::
 
-Once `struct` was marked as `#[napi(object)]`, you can use it as function arguments type or return type.
+Once `struct` is marked as `#[napi(object)]`, you can use it as function arguments type or return type.
 
 ```rust title=lib.rs
 #[napi(object)]
@@ -42,5 +42,5 @@ fn create_cat() -> Pet {
 ```
 
 :::caution
-The JavaScript Object passed in or returned from `Rust` is cloned. Which means any mutation on JavaScript `Object` will not affect the original Rust `struct`. And any mutation on Rust `struct` will not affect the JavaScript `Object` either.
+The JavaScript Object passed in or returned from Rust is cloned. This means any mutation on JavaScript `Object` will not affect the original Rust `struct`. And any mutation on Rust `struct` will not affect the JavaScript `Object` either.
 :::

--- a/docs/concepts/threadsafe-function.md
+++ b/docs/concepts/threadsafe-function.md
@@ -1,6 +1,6 @@
 ---
 title: 'ThreadsafeFunction'
-description: Call JavaScript callback in other threads.
+description: Call a JavaScript callback in other threads.
 ---
 
 [`ThreadSafe Function`](https://nodejs.org/api/n-api.html#asynchronous-thread-safe-function-calls) is a complex concept in Node.js. As we all know, Node.js is single threaded, so you can't access [`napi_env`](https://nodejs.org/api/n-api.html#napi_env), [`napi_value`](https://nodejs.org/api/n-api.html#napi_value), and [`napi_ref`](https://nodejs.org/api/n-api.html#napi_ref) on another thread.

--- a/docs/concepts/threadsafe-function.md
+++ b/docs/concepts/threadsafe-function.md
@@ -1,15 +1,15 @@
 ---
 title: 'ThreadsafeFunction'
-description: Call JavaScript callback in the other threads.
+description: Call JavaScript callback in other threads.
 ---
 
-[`ThreadSafe Function`](https://nodejs.org/api/n-api.html#asynchronous-thread-safe-function-calls) is a complex concept in `Node.js`. As we all know, `Node.js` is single threaded, so you can't access the [`napi_env`](https://nodejs.org/api/n-api.html#napi_env), [`napi_value`](https://nodejs.org/api/n-api.html#napi_value) and [`napi_ref`](https://nodejs.org/api/n-api.html#napi_ref) on the other thread.
+[`ThreadSafe Function`](https://nodejs.org/api/n-api.html#asynchronous-thread-safe-function-calls) is a complex concept in Node.js. As we all know, Node.js is single threaded, so you can't access [`napi_env`](https://nodejs.org/api/n-api.html#napi_env), [`napi_value`](https://nodejs.org/api/n-api.html#napi_value), and [`napi_ref`](https://nodejs.org/api/n-api.html#napi_ref) on another thread.
 
 :::info
-[`napi_env`](https://nodejs.org/api/n-api.html#napi_env), [`napi_value`](https://nodejs.org/api/n-api.html#napi_value) and [`napi_ref`](https://nodejs.org/api/n-api.html#napi_ref) is low level concept in `Node-API`, the `#[napi]` of **NAPI-RS** is built on top of it. **NAPI-RS** also provides [low level API](../compat-mode/concepts/env) to access the original `Node-API`.
+[`napi_env`](https://nodejs.org/api/n-api.html#napi_env), [`napi_value`](https://nodejs.org/api/n-api.html#napi_value), and [`napi_ref`](https://nodejs.org/api/n-api.html#napi_ref) are low level concepts in `Node-API`, which the `#[napi]` macro of **NAPI-RS** is built on top of. **NAPI-RS** also provides a [low level API](../compat-mode/concepts/env) to access the original `Node-API`.
 :::
 
-`Node-API` provide the complex `ThreadSafe Function` APIs to call the `JavaScript` function on the other thread. It's very complex so does many of developers can not understand and use it correctly. **NAPI-RS** provides a limited version of `ThreadSafe Function` APIs to make it easier to use:
+`Node-API` provide the complex `ThreadSafe Function` APIs to call the JavaScript function on the other thread. It's very complex so many developers don't understand how to use it correctly. **NAPI-RS** provides a limited version of `ThreadSafe Function` APIs to make it easier to use:
 
 ```rust {10} title=lib.rs
 use std::thread;
@@ -41,7 +41,7 @@ pub fn call_threadsafe_function(callback: JsFunction) -> Result<()> {
 export function callThreadsafeFunction(callback: (...args: any[]) => any): void
 ```
 
-`ThreadsafeFunction` is very complex so **NAPI-RS** do not provides the precise `TypeScript` definition generation of it. If you want to have a better `TypeScript` type, you can use `#[napi(ts_args_type)]` to override the type of `JsFunction` argument:
+`ThreadsafeFunction` is very complex so **NAPI-RS** does not provide the precise TypeScript definition generation of it. If you want to have a better TypeScript type, you can use `#[napi(ts_args_type)]` to override the type of `JsFunction` argument:
 
 ```rust {8} title=lib.rs
 use std::thread;
@@ -77,7 +77,7 @@ export function callThreadsafeFunction(
 
 ## ErrorStrategy
 
-There are two differences error handling strategy for `Threadsafe Function`. The strategy could be defined in the second generic parameter of `ThreadsafeFunction`:
+There are two different error handling strategies for `Threadsafe Function`. The strategy can be defined in the second generic parameter of `ThreadsafeFunction`:
 
 ```rust title=lib.rs
 let tsfn: ThreadsafeFunction<u32, ErrorStrategy::CalleeHandled> = ...
@@ -87,11 +87,11 @@ The first argument in the generic parameter of course is the return type of the 
 
 ### `ErrorStrategy::CalleeHandled`
 
-`Err` from Rust code will be pass into the first argument of the JavaScript callback. This behavior is following the async callback conventions from Node.js: https://nodejs.org/en/knowledge/errors/what-are-the-error-conventions/. Many async API in Node.js designed in this shape, like `fs.read`.
+`Err` from Rust code will be pass into the first argument of the JavaScript callback. This behavior follows the async callback conventions from Node.js: https://nodejs.org/en/knowledge/errors/what-are-the-error-conventions/. Many async APIs in Node.js are designed in this shape, like `fs.read`.
 
-With the `ErrorStrategy::CalleeHandled`, you must call the `ThreadsafeFunction` with `Result` type, so that the `Error` will be handled and pass back to the JavaScript callback:
+With `ErrorStrategy::CalleeHandled`, you must call the `ThreadsafeFunction` with the `Result` type, so that the `Error` will be handled and passed back to the JavaScript callback:
 
-```rust {15} title=lib.rs
+```rust {17} title=lib.rs
 use std::thread;
 
 use napi::{
@@ -99,15 +99,18 @@ use napi::{
   threadsafe_function::{ErrorStrategy, ThreadsafeFunction, ThreadsafeFunctionCallMode},
 };
 
-#[napi]
+#[napi(ts_args_type = "callback: (err: null | Error, result: number) => void")]
 pub fn call_threadsafe_function(callback: JsFunction) -> Result<()> {
   let tsfn: ThreadsafeFunction<u32, ErrorStrategy::CalleeHandled> = callback
     .create_threadsafe_function(0, |ctx| {
       ctx.env.create_uint32(ctx.value + 1).map(|v| vec![v])
     })?;
-  thread::spawn(move || {
-    tsfn.call(Ok(n), ThreadsafeFunctionCallMode::Blocking);
-  });
+  for n in 0..100 {
+    let tsfn = tsfn.clone();
+    thread::spawn(move || {
+      tsfn.call(Ok(n), ThreadsafeFunctionCallMode::Blocking);
+    });
+  }
   Ok(())
 }
 ```
@@ -116,9 +119,9 @@ pub fn call_threadsafe_function(callback: JsFunction) -> Result<()> {
 
 No `Error` will be passed back to the JavaScript side. You can use this strategy to avoid the `Ok` wrapping in the Rust side if your code will never return `Err`.
 
-With this strategy, `ThreadsafeFunction` doesn't need to be called with `Result<T>`, and the first argument of JavaScript callback is the value from the Rust, not the `Error | null`.
+With this strategy, `ThreadsafeFunction` doesn't need to be called with `Result<T>`, and the first argument of JavaScript callback is the value from the Rust, not `Error | null`.
 
-```rust {15} title=lib.rs
+```rust {17} title=lib.rs
 use std::thread;
 
 use napi::{
@@ -132,9 +135,12 @@ pub fn call_threadsafe_function(callback: JsFunction) -> Result<()> {
     .create_threadsafe_function(0, |ctx| {
       ctx.env.create_uint32(ctx.value + 1).map(|v| vec![v])
     })?;
-  thread::spawn(move || {
-    tsfn.call(n, ThreadsafeFunctionCallMode::Blocking);
-  });
+  for n in 0..100 {
+    let tsfn = tsfn.clone();
+    thread::spawn(move || {
+      tsfn.call(n, ThreadsafeFunctionCallMode::Blocking);
+    });
+  }
   Ok(())
 }
 ```

--- a/docs/concepts/types-overwrite.md
+++ b/docs/concepts/types-overwrite.md
@@ -3,16 +3,16 @@ title: 'Types Overwrite'
 description: Overwrite the arguments and return TypeScript types.
 ---
 
-In most cases, **NAPI-RS** will generate the right TypeScript types for you. But in some scenario, you may want overwrite the arguments or return type.
+In most cases, **NAPI-RS** will generate the right TypeScript types for you. But in some scenarios, you may want to overwrite the arguments or return type.
 
-[ThreadsafeFunction](./threadsafe-function) is an example, because the `ThreadsafeFunction` is too complex, **NAPI-RS** can't generate the right TypeScript types for it. You always need to overwrite the arguments type of it.
+[ThreadsafeFunction](./threadsafe-function) is an example, because the `ThreadsafeFunction` is too complex, **NAPI-RS** can't generate the right TypeScript types for it. You always need to overwrite its argument type.
 
 ## `ts_args_type`
 
 Rewrite the arguments type of the function, **NAPI-RS** will put the rewritten type into the brace of the function signature.
 
 ```rust {1} title=lib.rs
-#[napi(ts_args_type="a: (err: Error | null, result: number) => void")]
+#[napi(ts_args_type="callback: (err: null | Error, result: number) => void")]
 fn call_threadsafe_function(callback: JsFunction) -> Result<()> {
   let tsfn: ThreadsafeFunction<u32, ErrorStrategy::CalleeHandled> = callback
     .create_threadsafe_function(0, |ctx| {
@@ -38,7 +38,7 @@ export function callThreadsafeFunction(
 
 ## `ts_return_type`
 
-Rewrite the return type of the function, **NAPI-RS** will put the rewritten type into the end of the function signature.
+Rewrite the return type of the function, **NAPI-RS** will add the rewritten type to the end of the function signature.
 
 ```rust {1} title=lib.rs
 #[napi(ts_return_type="number")]

--- a/docs/concepts/types-overwrite.md
+++ b/docs/concepts/types-overwrite.md
@@ -1,6 +1,6 @@
 ---
 title: 'Types Overwrite'
-description: Overwrite the arguments and return TypeScript types.
+description: Overwrite the argument and return TypeScript types.
 ---
 
 In most cases, **NAPI-RS** will generate the right TypeScript types for you. But in some scenarios, you may want to overwrite the arguments or return type.

--- a/docs/concepts/values.md
+++ b/docs/concepts/values.md
@@ -103,10 +103,11 @@ export function isGood(): boolean
 ```rust title=lib.rs
 #[napi]
 fn with_buffer(buf: Buffer) {
-	let buf = Vec::<u8>::from(buf);
-	// do something
+  let buf: Vec<u8> = buf.into();
+  // do something
 }
 
+#[napi]
 fn read_buffer(file: String) -> Buffer {
 	Buffer::from(std::fs::read(file).unwrap())
 }
@@ -152,7 +153,7 @@ export function logStringField(obj: object): void
 export function createObj(): object
 ```
 
-If you want `napi-rs` convert objects from JavaScript with the same shape defined in Rust, you could use `#[napi]` macro with `object` attribute.
+If you want **NAPI-RS** to convert objects from JavaScript with the same shape defined in Rust, you can use the `#[napi]` macro with the `object` attribute.
 
 ```rust title=lib.rs
 /// #[napi(object)] requires all struct fields to be public

--- a/docs/concepts/values.md
+++ b/docs/concepts/values.md
@@ -1,9 +1,9 @@
 ---
 title: 'Values'
-description: 'Conversion relation between Rust and JavaScript types'
+description: Conversions between Rust and JavaScript types.
 ---
 
-Conversion relation between Rust and JavaScript types
+Conversions between Rust and JavaScript types.
 
 ### Undefined
 


### PR DESCRIPTION
- grammar fixes
- consistency when referring to things
- fix a few examples

This example does not compile and I'm not sure how to fix it:
https://github.com/napi-rs/website/blob/611fac839cb8e666b926b5faf025d5907f7c3a9f/docs/concepts/inject-env.md#L12-L20
```
error[E0596]: cannot borrow `env` as mutable, as it is not declared as mutable
 --> src/lib.rs:9:3
  |
8 | fn call_env(env: Env, length: u32) -> Result<External<Vec<u32>>> {
  |             --- help: consider changing this to be mutable: `mut env`
9 |   env.adjust_external_memory(length as i64)?;
  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot borrow as mutable
  ```
a different error with `#[napi]` occurs after changing to `&mut Env`