### PR TITLE
Display last update time on each page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -52,6 +52,7 @@ module.exports = {
           routeBasePath: 'docs',
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl: 'https://github.com/napi-rs/website/edit/main/docs',
+          showLastUpdateTime: true,
         },
         blog: {
           showReadingTime: true,


### PR DESCRIPTION
Now we'll get something like this (without author's name):

![image](https://user-images.githubusercontent.com/13461315/147515798-3da3efb8-0323-4e89-834f-6b7402330ddc.png)

I didn't tested this locally, but I've followed this: https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs