### PR TITLE
`target tripe` to `target triple`

### DIFF
--- a/pages/docs/cli/napi-config.en.mdx
+++ b/pages/docs/cli/napi-config.en.mdx
@@ -36,7 +36,7 @@ import Callout from 'nextra-theme-docs/callout'
 | `triples.additional` | Additional triples besides the default triples you want to build. Target triples could be found in the output of `rustup target list` command.                                                                            |
 | `package.name`       | Override the `name` field in `package.json`. See [Build#js-package-name](./build#note-for---js-package-name) for usage.                                                                                                   |
 
-## What is `target tripe`
+## What is `target triple`
 
 See [rustc/platform-support](https://doc.rust-lang.org/nightly/rustc/platform-support.html) and [LLVM/CrossCompilation](https://clang.llvm.org/docs/CrossCompilation.html#target-triple)
 


### PR DESCRIPTION
Small typo missing an "L".