### PR TITLE
docs(native-module): fix references

### DIFF
--- a/pages/docs/deep-dive/native-module.en.mdx
+++ b/pages/docs/deep-dive/native-module.en.mdx
@@ -178,3 +178,10 @@ node-gyp is a command line program that can be run directly from `$ node-gyp` af
 ## Conclusion
 
 In this chapter, we introduced what the Node.js native addon is and how to compile it. In the next chapter, we will review the history of API changes related to the native addon in Node.js and formally introduce our protagonist: the N-API.
+
+## References
+
+[^1]: https://en.wikipedia.org/wiki/Magic_number_(programming)
+[^2]: https://github.com/nodejs/node/blob/v6.9.4/src/node.cc#L2427-L2502
+[^3]: GYP means _Generate Your Projects_, a build system developed by Google. For more details: https://gyp.gsrc.io.
+[^4]: The config file of GYP usually has an extension of _.gyp, or _.gypi. It is a JSON-like file.

--- a/style.css
+++ b/style.css
@@ -13,3 +13,9 @@ article pre code .line.highlighted::before {
 .dark {
   --nextra-primary-hue: 16deg;
 }
+
+/* HACK Hide the title of footnotes section. Since Nextra cannot handle footnotes style correctly */
+/* For detail: https://github.com/shuding/nextra/pull/2104 */
+section.footnotes > h2 {
+  display: none;
+}

--- a/style.css
+++ b/style.css
@@ -15,7 +15,7 @@ article pre code .line.highlighted::before {
 }
 
 /* HACK Hide the title of footnotes section. Since Nextra cannot handle footnotes style correctly */
-/* For detail: https://github.com/shuding/nextra/pull/2104 */
+/* For details: https://github.com/shuding/nextra/pull/2104 */
 section.footnotes > h2 {
   display: none;
 }


### PR DESCRIPTION
For deep dive / native module page, https://napi.rs/docs/deep-dive/native-module:

## Before

1. Citation marks fail to point to correct reference.
<img width="857" alt="image" src="https://github.com/napi-rs/website/assets/8041462/117d0bcf-e2bb-4ea0-a414-44b56306d6f5">

2. No references section.

## After
- Citation marks work properly.
<img width="865" alt="image" src="https://github.com/napi-rs/website/assets/8041462/bae26689-2adf-405d-8beb-eef393940cf6">

- At the end of page, a Reference section added.
<img width="870" alt="image" src="https://github.com/napi-rs/website/assets/8041462/a82bcb55-757a-484f-9ac0-196ad29dad01">
