### PR TITLE
Add Brazilian Portuguese language support to documentation

### DIFF
--- a/components/title.pt-BR.jsx
+++ b/components/title.pt-BR.jsx
@@ -1,0 +1,8 @@
+import { NodeJS, Rust } from './lang'
+
+export const TitlePTBR = () => (
+  <p>
+    <span style={{ fontSize: '36px', fontWeight: 'bold' }}>NAPI-RS</span> é um
+    framework para construir addons pré-compilados para <NodeJS /> em <Rust />.
+  </p>
+)

--- a/next.config.js
+++ b/next.config.js
@@ -9,7 +9,7 @@ const withNextra = require('nextra')({
 module.exports = withNextra({
   i18n: {
     defaultLocale: process.env.LOCALE || 'en',
-    locales: ['en', 'cn'],
+    locales: ['en', 'cn', 'pt-BR'],
   },
   webpack(config, { dev, isServer }) {
     if (!dev && !isServer) {

--- a/nextra.config.js
+++ b/nextra.config.js
@@ -4,11 +4,13 @@ import Script from 'next/script'
 const LOADING_LOCALES = {
   en: 'Loading',
   cn: '正在加载',
+  'pt-BR': 'Carregando',
 }
 
 const PLACEHOLDER_LOCALES = {
   en: 'Search documentation',
   cn: '搜索文档',
+  'pt-BR': 'Buscar documentação',
 }
 
 export default {
@@ -127,6 +129,8 @@ export default {
       switch (locale) {
         case 'cn':
           return '在 GitHub 上编辑本页 →'
+        case 'pt-BR':
+          return 'Editar essa página no Github →'
         default:
           return 'Edit this page on GitHub →'
       }
@@ -150,6 +154,7 @@ export default {
   i18n: [
     { locale: 'en', text: 'English' },
     { locale: 'cn', text: '简体中文' },
+    { locale: 'pt-BR', text: 'Português do Brasil' },
   ],
   useNextSeoProps: () => ({ titleTemplate: '%s \u2013 NAPI-RS' }),
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "build": "next build",
     "build:en": "next build",
     "build:cn": "cross-env LOCALE=cn next build",
+    "build:pt-BR": "cross-env LOCALE=pt-BR next build",
     "format": "prettier -w .",
     "postinstall": "husky install"
   },

--- a/pages/_meta.pt-BR.json
+++ b/pages/_meta.pt-BR.json
@@ -1,0 +1,18 @@
+{
+  "index": {
+    "title": "Introdução",
+    "display": "hidden"
+  },
+  "docs": {
+    "title": "Documentação",
+    "type": "page"
+  },
+  "blog": {
+    "title": "Blog",
+    "type": "page"
+  },
+  "changelog": {
+    "title": "Changelog",
+    "type": "page"
+  }
+}

--- a/pages/docs/_meta.pt-BR.json
+++ b/pages/docs/_meta.pt-BR.json
@@ -1,0 +1,10 @@
+{
+  "introduction": "Introdução",
+  "concepts": "Conceitos",
+  "compat-mode": "Modo de compatibilidade",
+  "cli": "CLI",
+  "deep-dive": "Aprofundamento",
+  "cross-build": "Compilação cruzada",
+  "ecosystem": "Ecossistema",
+  "more": "Mais"
+}

--- a/pages/docs/cli/_meta.pt-BR.json
+++ b/pages/docs/cli/_meta.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "build": "Build",
+  "artifacts": "Artifacts",
+  "pre-publish": "Prepublish",
+  "napi-config": "NAPI Config"
+}

--- a/pages/docs/cli/artifacts.pt-BR.mdx
+++ b/pages/docs/cli/artifacts.pt-BR.mdx
@@ -1,0 +1,184 @@
+---
+description: napi artifacts command in @napi-rs/cli.
+---
+
+# Artifacts
+
+import { Callout } from 'nextra-theme-docs'
+import { Green } from '../../../components/chalk'
+
+Gerenciamento de [artifacts](https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts) do GitHub Actions.
+
+<Callout>
+  Este comando geralmente é usado na etapa de publicação, antes do comando `npm
+  publish` e após a etapa de `Download artifacts`.
+</Callout>
+
+## Flags List
+
+| Flag          | Tipo/Valor padrão    | Descrição                                                                                           |
+| ------------- | -------------------- | --------------------------------------------------------------------------------------------------- |
+| `-d` ,`--dir` | `String`/`artifacts` | O diretório de origem que contém todos os resultados dos `artifacts` gerados na fase de compilação. |
+| `--dist`      | `String`/`npm`       | O diretório de distribuição para onde o complemento nativo será copiado.                            |
+
+## Como isso funciona
+
+Suponha que você tenha um projeto que cria um complemento(addon) nativo para estas plataformas:
+
+- `x86_64-apple-darwin`
+- `x86_64-pc-windows-msvc`
+- `x86_64-unknown-linux-gnu`
+- `aarch64-apple-darwin`
+- `aarch64-linux-android`
+- `aarch64-unknown-linux-gnu`
+- `aarch64-unknown-linux-musl`
+- `aarch64-pc-windows-msvc`
+- `armv7-unknown-linux-gnueabihf`
+- `arm-linux-androideabi`
+- `x86_64-unknown-linux-musl`
+- `x86_64-unknown-freebsd`
+- `i686-pc-windows-msvc`
+
+E você pode baixar esses artefatos através de `actions/download-artifact`:
+
+```yaml
+- name: Download all artifacts
+  uses: actions/download-artifact@v2
+  with:
+  	path: artifacts
+```
+
+Agora a estrutura de diretórios ficará assim:
+
+```text {4,6,8,10,12,14,16,18,20,22,24,26,28} filename="directory structure"
+.
+├── artifacts
+|   ├── bindings-x86_64-apple-darwin
+|   │   └── blake.darwin-x64.node
+|   ├── bindings-x86_64-pc-windows-msvc
+|   │   └── blake.win32-x64.node
+|   ├── bindings-x86_64-unknown-linux-gnu
+|   │   └── blake.linux-x64-gnu.node
+|   ├── bindings-aarch64-apple-darwin
+|   │   └── blake.darwin-arm64.node
+|   ├── bindings-aarch64-linux-android
+|   │   └── blake.android-arm64.node
+|   ├── bindings-aarch64-unknown-linux-gnu
+|   │   └── blake.linux-arm64-gnu.node
+|   ├── bindings-aarch64-unknown-linux-musl
+|   │   └── blake.linux-arm64-musl.node
+|   ├── bindings-aarch64-pc-windows-msvc
+|   │   └── blake.win32-arm64-msvc.node
+|   ├── bindings-armv7-unknown-linux-gnueabihf
+|   │   └── blake.linux-arm-gnueabihf.node
+|   ├── bindings-arm-linux-androideabi
+|   │   └── blake.android-arm-eabi.node
+|   ├── bindings-x86_64-unknown-linux-musl
+|   │   └── blake.linux-x64-musl.node
+|   ├── bindings-x86_64-unknown-freebsd
+|   │   └── blake.freebsd-x64.node
+|   └── bindings-i686-pc-windows-msvc
+|       └── blake.win32-ia32-msvc.node
+├── npm
+│   ├── android-arm-eabi
+│   │   ├── README.md
+│   │   └── package.json
+│   ├── android-arm64
+│   │   ├── README.md
+│   │   └── package.json
+│   ├── darwin-arm64
+│   │   ├── README.md
+│   │   └── package.json
+│   ├── darwin-x64
+│   │   ├── README.md
+│   │   └── package.json
+│   ├── freebsd-x64
+│   │   ├── README.md
+│   │   └── package.json
+│   ├── linux-arm-gnueabihf
+│   │   ├── README.md
+│   │   └── package.json
+│   ├── linux-arm64-gnu
+│   │   ├── README.md
+│   │   └── package.json
+│   ├── linux-arm64-musl
+│   │   ├── README.md
+│   │   └── package.json
+│   ├── linux-x64-gnu
+│   │   ├── README.md
+│   │   └── package.json
+│   ├── linux-x64-musl
+│   │   ├── README.md
+│   │   └── package.json
+│   ├── win32-arm64-msvc
+│   │   ├── README.md
+│   │   └── package.json
+│   ├── win32-ia32-msvc
+│   │   ├── README.md
+│   │   └── package.json
+│   └── win32-x64-msvc
+│       ├── README.md
+│       └── package.json
+```
+
+Como você pode ver, precisamos copiar todos os arquivos <Green>`.node`</Green> para o diretório `npm` para que possamos publicá-los por meio do comando [`napi prepublish`](./pre-publish).
+
+O comando `napi artifacts` fará esse trabalho para você. Suponha que as flags <Green>`-d`</Green> e <Green>`--dist`</Green> tenham o valor padrão, e a estrutura de diretórios seja a mesma que abaixo. Após a execução do comando `napi artifacts`, a estrutura de diretórios se tornará:
+
+```text {6,10,14,18,22,26,30,34,38,42,46,50,54} filename="directory structure"
+.
+├── artifacts
+├── npm
+│   ├── android-arm-eabi
+│   │   ├── README.md
+|   |   ├── blake.android-arm-eabi.node
+│   │   └── package.json
+│   ├── android-arm64
+│   │   ├── README.md
+|   |   ├── blake.android-arm64.node
+│   │   └── package.json
+│   ├── darwin-arm64
+│   │   ├── README.md
+|   |   ├── blake.darwin-arm64.node
+│   │   └── package.json
+│   ├── darwin-x64
+│   │   ├── README.md
+|   |   ├── blake.darwin-x64.node
+│   │   └── package.json
+│   ├── freebsd-x64
+│   │   ├── README.md
+|   |   ├── blake.freebsd-x64.node
+│   │   └── package.json
+│   ├── linux-arm-gnueabihf
+│   │   ├── README.md
+|   |   ├── blake.linux-arm-gnueabihf.node
+│   │   └── package.json
+│   ├── linux-arm64-gnu
+│   │   ├── README.md
+|   |   ├── blake.linux-arm64-gnu.node
+│   │   └── package.json
+│   ├── linux-arm64-musl
+│   │   ├── README.md
+|   |   ├── blake.linux-arm64-musl.node
+│   │   └── package.json
+│   ├── linux-x64-gnu
+│   │   ├── README.md
+|   |   ├── blake.linux-x64-gnu.node
+│   │   └── package.json
+│   ├── linux-x64-musl
+│   │   ├── README.md
+|   |   ├── blake.linux-x64-musl.node
+│   │   └── package.json
+│   ├── win32-arm64-msvc
+│   │   ├── README.md
+|   |   ├── blake.win32-arm64-msvc.node
+│   │   └── package.json
+│   ├── win32-ia32-msvc
+│   │   ├── README.md
+|   |   ├── blake.win32-ia32-msvc.node
+│   │   └── package.json
+│   └── win32-x64-msvc
+│       ├── README.md
+|       ├── blake.win32-x64-msvc.node
+│       └── package.json
+```

--- a/pages/docs/cli/build.pt-BR.mdx
+++ b/pages/docs/cli/build.pt-BR.mdx
@@ -1,0 +1,146 @@
+---
+description: napi build command in @napi-rs/cli.
+---
+
+# Build
+
+import { Green, Rust, Warning } from '../../../components/chalk'
+
+## Flags list
+
+| Flag                | Tipo/Valor padrão                                                                 | Descrição                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--platform`        | `Boolean`/`false`                                                                 | Adiciona platform triple ao arquivo `.node`. <Green>[name].linux-x64-gnu.node</Green> por exemplo.                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `--release`         | `Boolean`/`false`                                                                 | Bypass para <Green>cargo build --release</Green>                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `--config` ou `-c`  | `String`/`package.json`                                                           | Caminho da configuração do NAPI, apenas o formato JSON é aceito. O padrão é <Green>package.json</Green>                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `--cargo-name`      | `String`/O campo `[package].name` no <Rust>Cargo.toml</Rust> sob o comando `cwd`. | `@napi-rs/cli` irá copiar o arquivo `./target/release/lib_[CARGO_NAME].[dll/dylib/so]` para `[NAPI_NAME].[TRIPLE?].node` por padrão. O `[CARGO_NAME]` no caminho de origem é lido do <Rust>Cargo.toml</Rust> no `cwd` por padrão. Se você estiver compilando algum outro crate que não seja o cwd atual usando a flag `cargo build -p`, você deve substituir o `CARGO_NAME` com `--cargo-name`.                                                                                                         |
+| `--target`          | `String`/`undefined`                                                              | Bypass para <Green>cargo build --target</Green>, use esta flag para compilar cruzado.<br /><Warning>⚠️ Se nenhum `--target` for especificado, `@napi-rs/cli` invocará `rustup` para determinar o target atual para o qual você está compilando. Certifique-se de ter `rustup` instalado em seu `PATH` se esta flag for omitida.</Warning>                                                                                                                                                               |
+| `--features`        | `String`/`undefined`                                                              | Bypass para <Green>cargo build --features</Green>                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `--bin`             | `String`/`undefined`                                                              | Bypass para <Green>cargo build --bin</Green>                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `--const-enum`      | `Boolean`/`true`                                                                  | Gerar `const enum` no arquivo `.d.ts` ou não.                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `--dts`             | `String`/`index.d.ts`                                                             | O nome do arquivo e o caminho do arquivo `.d.ts` gerado, em relação ao comando cwd. <br />Se você não quer que o **NAPI-RS** gere o arquivo `.d.ts` para você, você pode desabilitar o recurso `type-def` no crate `napi-derive`. <br />ex: `napi-derive = { version = "2", default-features = false }`<br /><Warning>⚠️ Se o recurso `type-def` estiver desabilitado, o **NAPI-RS** também não gerará o arquivo de binding JavaScript para você devido à falta de **_informações de tipo_**</Warning>. |
+| `-p`                | `String`/`undefined`                                                              | Bypass para <Green>cargo build -p</Green>                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `--cargo-flags`     | `String`/`''`                                                                     | All the others flag bypass to <Green>cargo build</Green> command.                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `--js`              | `String`/`index.js`                                                               | O nome do arquivo e o caminho do arquivo de binding JavaScript, relativos ao diretório de comando `cwd`, Passe <Warning>false</Warning> para desativá-lo. Apenas tem efeito se <Green>--platform</Green> for especificado **e** o recurso `type-def` em `napi-derive` estiver habilitado.                                                                                                                                                                                                               |
+| `--js-package-name` | `String`/`name` campo no <Green>package.json</Green> sob o comando cwd.           | O nome dos pacotes no arquivo de binding js gerado, Apenas afeta se <Green>--js</Green> for afetado. [#Observação](#note-for---js-package-name)<br /><Warning>⚠️ Esta flag substituirá o campo `package.name` na configuração do napi</Warning><br />Você pode omiti-lo se tiver especificado a configuração `package.name` do [**napi config**](./napi-config)                                                                                                                                         |
+| `--cargo-cwd`       | `String`/`process.cwd()`                                                          | O cwd do `Cargo.toml`. Especifique essa flag se você não deseja passar <Green>--cargo-name</Green>                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `--pipe`            | `String`/`undefined`                                                              | Encaminhe os arquivos <Green>.js/.d.ts</Green> gerados para este comando, ex: <Green>`prettier -w`</Green>                                                                                                                                                                                                                                                                                                                                                                                              |
+| `--zig`             | `Boolean`/`false`                                                                 | `@napi-rs/cli` usará [zig](https://andrewkelley.me/post/zig-cc-powerful-drop-in-replacement-gcc-clang.html) como `cc` / `cxx` e `linker` para compilar seu programa.                                                                                                                                                                                                                                                                                                                                    |
+| `--zig-abi-suffix`  | `String`/`''`                                                                     | O sufixo da versão da ABI `zig --target`. Ex: `--target x86_64-unknown-linux-gnu` <Green>--zig-abi-suffix=2.17</Green>                                                                                                                                                                                                                                                                                                                                                                                  |
+| `--zig-link-only`   | `Boolean/false`                                                                   | `@napi-rs/cli` configurará as variáveis de ambiente `CC` e `CXX` para usar `zig cc`/`zig c++` para compilar cruzadamente as dependências C/C++ nos crates. Mas se você já configurou a cadeia de ferramentas de compilação cruzada C/C++, talvez queira usar apenas `zig` linker de compilação cruzada. Passe esta flag para `@napi-rs/cli` e então não será configurado as variáveis de ambiente `CC` e `CXX` para suas compilações.                                                                   |
+
+## Observações para `--js-package-name`
+
+Na seção de [aprofundamento](../introduction/getting-started#deep-dive), recomendamos que você publique seu pacote sob um [`escopo npm`](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages/). Mas se você estiver migrando um pacote existente que não está sob um [`escopo npm`](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages/) ou simplesmente não deseja que seu pacote esteja sob um [`escopo npm`](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages/) , você pode acionar a [_deteção de spam do npm_](https://stackoverflow.com/questions/48668389/npm-publish-failed-with-package-name-triggered-spam-detection/54135900#54135900) ao publicar os pacotes de plataforma nativa. Como `snappy-darwin-x64` `snappy-darwin-arm64` etc...
+
+Nesse caso, você pode publicar seus pacotes de plataforma sob um [`escopo npm`](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages/) para evitar a [_deteção de spam do npm_](https://stackoverflow.com/questions/48668389/npm-publish-failed-with-package-name-triggered-spam-detection/54135900#54135900). E seus usuários não precisam se preocupar com os pacotes nativos da plataforma em `optionalDependencies`. Como [`snappy`](https://github.com/Brooooooklyn/snappy/), os usuários só precisam instalá-lo via `yarn add snappy`. Mas os pacotes nativos da plataforma estão sob o escopo `@napi-rs`:
+
+```json
+{
+  "name": "snappy",
+  "version": "7.0.0",
+  "optionalDependencies": {
+    "@napi-rs/snappy-win32-x64-msvc": "7.0.0",
+    "@napi-rs/snappy-darwin-x64": "7.0.0",
+    "@napi-rs/snappy-linux-x64-gnu": "7.0.0",
+    "@napi-rs/snappy-linux-x64-musl": "7.0.0",
+    "@napi-rs/snappy-linux-arm64-gnu": "7.0.0",
+    "@napi-rs/snappy-win32-ia32-msvc": "7.0.0",
+    "@napi-rs/snappy-linux-arm-gnueabihf": "7.0.0",
+    "@napi-rs/snappy-darwin-arm64": "7.0.0",
+    "@napi-rs/snappy-android-arm64": "7.0.0",
+    "@napi-rs/snappy-android-arm-eabi": "7.0.0",
+    "@napi-rs/snappy-freebsd-x64": "7.0.0",
+    "@napi-rs/snappy-linux-arm64-musl": "7.0.0",
+    "@napi-rs/snappy-win32-arm64-msvc": "7.0.0"
+  }
+}
+```
+
+Para este caso, `@napi-rs/cli` fornece o `--js-package-name` para substituir a lógica de carregamento de pacotes gerados. Por exemplo, no `snappy`, temos um <Green>package.json</Green> assim:
+
+```json
+{
+  "name": "snappy",
+  "version": "7.0.0",
+  "napi": {
+    "name": "snappy"
+  }
+}
+```
+
+Sem a flag `--js-package-name`, `@napi-rs/cli` vai gerar a binding JavaScript para carregar pacotes nativos da plataforma para você:
+
+```js {10,22} filename="index.js"
+switch (platform) {
+  case 'darwin':
+    switch (arch) {
+      case 'x64':
+        localFileExisted = existsSync(join(__dirname, 'snappy.darwin-x64.node'))
+        try {
+          if (localFileExisted) {
+            nativeBinding = require('./snappy.darwin-x64.node')
+          } else {
+            nativeBinding = require('snappy-darwin-x64')
+          }
+        } catch (e) {
+          loadError = e
+        }
+        break
+      case 'arm64':
+        localFileExisted = existsSync(join(__dirname, 'snappy.darwin-arm64.node'))
+        try {
+          if (localFileExisted) {
+            nativeBinding = require('./snappy.darwin-arm64.node')
+          } else {
+            nativeBinding = require('snappy-darwin-arm64')
+          }
+        } catch (e) {
+          loadError = e
+        }
+        break
+      default:
+        throw new Error(`Unsupported architecture on macOS: ${arch}`)
+    }
+    break
+    ...
+}
+```
+
+Isso não é o que queremos. Então, construa com `--js-package-name` para substituir o `package name` no arquivo de binding JavaScript gerado: `napi build --release --platform --js-package-name @napi-rs/snappy`. Em seguida, o arquivo JavaScript gerado se tornará:
+
+```js {10,22} filename="index.js"
+switch (platform) {
+  case 'darwin':
+    switch (arch) {
+      case 'x64':
+        localFileExisted = existsSync(join(__dirname, 'snappy.darwin-x64.node'))
+        try {
+          if (localFileExisted) {
+            nativeBinding = require('./snappy.darwin-x64.node')
+          } else {
+            nativeBinding = require('@napi-rs/snappy-darwin-x64')
+          }
+        } catch (e) {
+          loadError = e
+        }
+        break
+      case 'arm64':
+        localFileExisted = existsSync(join(__dirname, 'snappy.darwin-arm64.node'))
+        try {
+          if (localFileExisted) {
+            nativeBinding = require('./snappy.darwin-arm64.node')
+          } else {
+            nativeBinding = require('@napi-rs/snappy-darwin-arm64')
+          }
+        } catch (e) {
+          loadError = e
+        }
+        break
+      default:
+        throw new Error(`Unsupported architecture on macOS: ${arch}`)
+    }
+    break
+    ...
+}
+```

--- a/pages/docs/cli/napi-config.pt-BR.mdx
+++ b/pages/docs/cli/napi-config.pt-BR.mdx
@@ -1,0 +1,53 @@
+---
+description: Config schema of NAPI-RS.
+---
+
+# NAPI Config
+
+import { Green } from '../../../components/chalk'
+
+O esquema de configuração do **NAPI-RS**.
+
+import { Callout } from 'nextra-theme-docs'
+
+<Callout>Todos os campos em `napi` são opcionais.</Callout>
+
+## Schema
+
+```ts
+{
+  napi?: {
+    name?: string
+    triples?: {
+      defaults?: boolean,
+      additional?: string[]
+    },
+    package?: {
+      name?: string
+    },
+    npmClient?: string
+  }
+}
+```
+
+| Field                |           Padrão           | Descrição                                                                                                                                                        |
+| -------------------- | :------------------------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`               |   <Green>`index`</Green>   | O nome do arquivo binário do arquivo `.node` gerado. Ex: <Green>`[NAME].[TRIPLE?].node`</Green> se torna <Green>`index.win32-x64-msvc.node`</Green>              |
+| `triples.defaults`   |   <Green>`true`</Green>    | Se deve habilitar os triples padrão. <br />Os triples padrão são `['x86_64-apple-darwin', 'x86_64-unknown-linux-gnu', 'x86_64-pc-windows-msvc']`.                |
+| `triples.additional` |    <Green>`[]`</Green>     | Triples adicionais além dos triplos padrão que você deseja construir. Triplos de destino(target) podem ser encontrados na saída do comando `rustup target list`. |
+| `package.name`       | <Green>`undefined`</Green> | Substitua o campo `name` no `package.json`. Veja [Build#js-package-name](./build#note-for---js-package-name) para uso.                                           |
+| `npmClient`          |    <Green>`npm`</Green>    | Especifique um cliente NPM diferente para uso ao executar ações do NPM, como publicação.                                                                         |
+
+## O que é `target triple`
+
+Veja [rustc/platform-support](https://doc.rust-lang.org/nightly/rustc/platform-support.html) e [LLVM/CrossCompilation](https://clang.llvm.org/docs/CrossCompilation.html#target-triple)
+
+> Os Targets são identificados por seus "target triple", que é a string usada para informar ao compilador que tipo de saída deve ser produzida.
+
+> O triplo tem o formato geral `<arch><sub>-<vendor>-<sys>-<abi>`, onde:
+>
+> - `arch` = `x86_64`, `i386`, `arm`, `thumb`, `mips`, etc.
+> - `sub` = ex: no ARM: `v5`, `v6m`, `v7a`, `v7m`, etc.
+> - `vendor` = `pc`, `apple`, `nvidia`, `ibm`, etc.
+> - `sys` = `none`, `linux`, `win32`, `darwin`, `cuda`, etc.
+> - `abi` = `eabi`, `gnu`, `android`, `macho`, `elf`, etc.

--- a/pages/docs/cli/pre-publish.pt-BR.mdx
+++ b/pages/docs/cli/pre-publish.pt-BR.mdx
@@ -1,0 +1,31 @@
+---
+description: napi prepublish command in @napi-rs/cli.
+---
+
+# Prepublish
+
+import { Green, Warning } from '../../../components/chalk'
+
+Rodando algumas preparações para publicação de pacotes **NAPI-RS**.
+
+import { Callout } from 'nextra-theme-docs'
+
+<Callout>
+  Este comando geralmente é usado nos scripts de ciclo de vida `prepublishOnly`
+  no `package.json`.
+</Callout>
+
+```json {2} filename="package.json"
+"scripts": {
+  "prepublishOnly": "napi prepublish -t npm"
+}
+```
+
+## Flags
+
+| Flag                | Tipo/Valor padrão    | Descrição                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| ------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--tagstyle,-t`     | `String`/`lerna`     | O estilo da tag do seu commit do git. Atualmente, oferecemos dois tipos de estilos: `npm` e `lerna`. Por exemplo, se você alterar a versão do seu pacote usando `npm version patch`, o último commit será `v1.2.1`. E o comando `napi prepublish -t npm` coletará as informações de `version` a partir da mensagem do último commit. Essas informações serão usadas para fazer upload dos artefatos para **GitHub Releases**. <br />Se o <Green>`--skip-gh-release`</Green> for fornecido, o <Green>`--tagstyle,-t`</Green> não terá efeito. |
+| `--skip-gh-release` | `Boolean`/`false`    | Se deseja pular o upload do binário da plataforma para **GitHub Release**.                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `-p,--prefix`       | `String`/`npm`       | O caminho no qual os pacotes da plataforma estão. `@napi-rs/cli` irá atualizar todos os arquivos `package.json` nele. Aumente o campo `version` para alinhar o `package.json` na raiz do projeto.                                                                                                                                                                                                                                                                                                                                            |
+| `-c,--config`       | `String`/`undefined` | O caminho do arquivo `package.json` a ser lido, relativo ao `process.cwd()`.<br />O arquivo `package.json` deve conter o campo de configuração `napi`.<br /><Warning>`@napi-rs/cli` irá escrever o campo `optionalDependencies` no `package.json`, e o `optionalDependencies` conterá todas as plataformas definidas no campo [`napi.triples`](./napi-config).</Warning>                                                                                                                                                                     |

--- a/pages/docs/compat-mode/_meta.pt-BR.json
+++ b/pages/docs/compat-mode/_meta.pt-BR.json
@@ -1,0 +1,4 @@
+{
+  "concepts": "Conceitos",
+  "recipes": "Recipes"
+}

--- a/pages/docs/compat-mode/concepts/_meta.pt-BR.json
+++ b/pages/docs/compat-mode/concepts/_meta.pt-BR.json
@@ -1,0 +1,8 @@
+{
+  "env": "Env",
+  "js-values": "JsValue",
+  "ref": "Reference",
+  "thread-safe-function": "Thread safe function",
+  "tokio": "Tokio",
+  "wrap": "Wrap native object"
+}

--- a/pages/docs/compat-mode/concepts/env.pt-BR.mdx
+++ b/pages/docs/compat-mode/concepts/env.pt-BR.mdx
@@ -1,0 +1,105 @@
+---
+description: Node-API Env.
+---
+
+# Env
+
+## Nas documentações do Node.js
+
+> `napi_env` é usado para representar um contexto que a implementação subjacente do N-API pode usar para persistir o estado específico da VM. Esta estrutura é passada para funções nativas quando são invocadas, e deve ser passada de volta ao fazer chamadas N-API. Especificamente, o mesmo `napi_env` que foi passado quando a função nativa inicial foi chamada deve ser passado para quaisquer chamadas N-API aninhadas subsequentes. Armazenar em cache o `napi_env` para fins de reutilização geral e passar o `napi_env` entre instâncias do mesmo addon em diferentes threads Worker não é permitido. O `napi_env` se torna inválido quando uma instância de um addon nativo é descarregada. A notificação deste evento é entregue por meio dos callbacks fornecidos para `napi_add_env_cleanup_hook` e `napi_set_instance_data`.
+
+{/* `Env` 是 `napi_env` 的 `Rust` 层抽象。在使用 `C/C++` 编写 Node.js Add-ons 的时候，进行任何 N-API 调用都要通过 `napi_env`，而在 `Rust` 中与之类似，任何 API 调用都需要经过 `Env` 这一数据结构。在 `napi-rs` 中，有四个途径可以与 `Env` 交互。 */}
+
+`Env` é uma abstração em camada de `Rust` sobre `napi_env`. Ao escrever Add-ons do Node.js em `C/C++`, qualquer chamada N-API passa por `napi_env`, e da mesma forma em `Rust`, qualquer chamada de API passa pela estrutura de dados `Env`. No `napi-rs`, existem quatro maneiras de interagir com `Env`.
+
+## 1. [CallContext](../recipes/call-context) em `js_function`
+
+`js_function` é uma forma de definir uma `JavaScript function` em `Rust`:
+
+```rust
+#[js_function(1)]
+fn hello(ctx: CallContext) -> Result<JsString> {
+  let argument_one = ctx.get::<JsString>(0)?.into_utf8()?;
+  ctx.env.create_string_from_std(format!("{} world!", argument_one.as_str()?))
+}
+```
+
+Há um campo `env` na estrutura `CallContext`.
+
+A funcionalidade do `Env` pode ser encontrada na [documentação do Env](https://docs.rs/napi/latest/napi/struct.Env.html).
+
+## 2. `contextless_function`
+
+`contextless_function` é muito semelhante a `js_function`, exceto que `contextless_function` não terá o **_Contexto_** desta `JavaScript function`.
+O que significa que em `contextless_function` você não pode obter os **_arguments_**, **_this_** ou qualquer outro dado relacional de contexto da função. Mas isso será mais eficiente em termos de desempenho, então pode ser usado em cenários sensíveis ao desempenho.
+
+```rust
+#[contextless_function]
+fn just_return_hello(env: Env) -> ContextlessResult<JsString> {
+  env.create_string("hello").map(Some)
+}
+```
+
+## 3. Método `resolve/reject` no [Task](../../concepts/async-task#task) trait
+
+O [Task](../../concepts/async-task#task) trait é um pouco complicado, veja sua [documentação](../../concepts/async-task#task) para uma entendimento melhor.
+
+`Env` será passado para seus métodos `resolve` e `reject`. Os dois métodos serão chamados na thread principal quando a tarefa assíncrona no pool de threads for concluída.
+
+```rust
+struct PlusOneAsync(u32);
+
+impl Task for PlusOneAsync {
+  type Output = u32;
+  type JsValue = JsNumber;
+
+  fn compute(&mut self) -> Result<Self::Output> {
+    Ok(self.0 + 1)
+  }
+
+  fn resolve(self, env: Env, output: Self::Output) -> Result<Self::JsValue> {
+    env.create_uint32(output)
+  }
+}
+
+#[js_function(1)]
+fn async_plus_one(ctx: CallContext) -> Result<JsNumber> {
+  let input_number: u32 = ctx.get::<JsNumber>(0)?.try_into()?;
+  let task = PlusOneAsync(input_number);
+  ctx.env.spawn(task).map(|t| t.promise_object())
+}
+```
+
+```js
+asyncPlusOne(1).then((result) => {
+  console.log(result) // 2
+})
+```
+
+## 4. `ThreadSafeCallContext` em [Thread safe function](./thread-safe-function)
+
+```rust
+#[js_function(1)]
+fn thread_safe_function(ctx: CallContext) -> Result<JsUndefined> {
+  let callback: JsFunction = ctx.get(0)?;
+  let tsfn = ctx.create_threadsafe_function(&callback, 0, |ctx: ThreadSafeCallContext<u32>| {
+    ctx.env.create_uint32(ctx.value).map(|js_value| vec![js_value])
+  })?;
+
+  std::thread::spawn(move || {
+    tsfn.call(Ok(1), ThreadsafeFunctionCallMode::NonBlocking);
+  });
+
+  ctx.env.get_undefined()
+}
+```
+
+```js
+threadSafeFunction((err, value) => {
+  if (err) {
+    console.error(err)
+    process.exit(1)
+  }
+  console.log(value) // 1
+})
+```

--- a/pages/docs/compat-mode/concepts/js-values.pt-BR.mdx
+++ b/pages/docs/compat-mode/concepts/js-values.pt-BR.mdx
@@ -1,0 +1,164 @@
+---
+description: N-API JsValue.
+---
+
+# JsValue
+
+`JsValue` representa o **_valor do JavaScript_** em `Rust`.
+
+## `JsUndefined`
+
+`undefined` em JavaScript representa a ausência de um valor definido. Não pode ser convertido em um valor Rust `Rust`, e nenhum valor `Rust` pode ser convertido em `JsUndefined`.
+
+A única maneira de criar um `JsUndefined` em Rust é chamando `Env::get_undefined()`.
+
+## `JsNull`
+
+Representa `null` em JavaScript. Assim como `JsUndefined`, não pode ser convertido para um valor `Rust`, e nenhum valor `Rust` pode ser convertido para ele.
+
+A única maneira de criar `JsNull` em Rust é chamando `Env::get_null()`.
+
+## `JsNumber`
+
+|      | f64                  | u32                  | i32                 | i64                 |
+| ---- | -------------------- | -------------------- | ------------------- | ------------------- |
+| From | `Env::create_double` | `Env::create_uint32` | `Env::create_int32` | `Env::create_int64` |
+| Into | `TryInto`            | `TryInto`            | `TryInto`           | `TryInto`           |
+
+```rust
+use std::convert::TryInto;
+
+use napi::*;
+
+#[js_function(1)]
+fn fib(ctx: CallContext) -> Result<JsNumber> {
+  let input_number: i64 = ctx.get::<JsNumber>(0)?.try_into()?;
+  ctx.env.create_int64(fibonacci_native(input_number))
+}
+
+#[inline(always)]
+fn fibonacci_native(n: i64) -> i64 {
+  match n {
+    1 | 2 => 1,
+    _ => fibonacci_native(n - 1) + fibonacci_native(n - 2),
+  }
+}
+```
+
+## `JsBoolean`
+
+`JsBoolean` representa um valor booleano em JavaScript.
+
+Use `JsBoolean::get_value()` para converter `JsBoolean` em `bool` do Rust. E `Env::get_boolean()` para converter `bool` do Rust em `JsBoolean`.
+
+```rust
+#[js_function(1)]
+fn not(ctx: CallContext) -> Result<JsBoolean> {
+  let condition: JsBoolean = ctx.get(0)?;
+  ctx.env.get_boolean(!condition.get_value()?)
+}
+```
+
+```js
+not(true) // false
+not(false) // true
+```
+
+## `JsString`
+
+Representa valores de `string` em JavaScript. Existem três tipos de encoding de `string` com os quais você pode interagir usando `N-API`: `utf8`, `utf16` e `latin1`.
+
+> Há um artigo que pode ajudá-lo a entender a história do encoding no Node.js: https://kevin.burke.dev/kevin/node-js-string-encoding/
+
+Você pode criar um `JsString` a partir de um `&str` em Rust usando `Env::create_string()`.
+Se você deseja obter o valor utf8 de um `JsString`, você deve usar `JsString::into_utf8()` para obter o valor utf8 explicitamente.
+
+```rust
+#[js_function(1)]
+fn world(ctx: CallContext) -> Result<JsString> {
+  // ou into_utf16/into_latin1 aqui
+  // Se você deseja usar into_latin1, deve habilitar o recurso `latin1` para `napi-rs`.
+  let input_string = ctx.get::<JsString>(0)?.into_utf8()?;
+  let output = format!("{} world!", input_string.as_str()?);
+  ctx.env.create_string(output.as_str())
+}
+```
+
+```js
+world('hello') // hello world!
+```
+
+## `JsBuffer`
+
+{/* 使用 JsBuffer 在 JavaScript 与 Rust 之间传递数据是开销最小的一种方式。 */}
+
+`JsBuffer` é usado para representar um valor `Buffer` no Node.js. Passar dados entre JavaScript e Rust usando `JsBuffer` tem uma pequena sobrecarga, então você pode preferi-lo em relação a outros tipos.
+
+Por exemplo, em alguns casos, converter uma `string` JavaScript em um `Buffer`, passá-lo para Rust como um `JsBuffer` e convertê-lo como um `&[u8]` é mais rápido do que passar a string diretamente para Rust. A implementação de string no V8 é muito mais complicada do que a de `ArrayBuffer`, que é como o `Buffer` é implementado.
+
+```rust
+#[js_function(1)]
+fn set_buffer(ctx: CallContext) -> Result<JsUndefined> {
+  let buf = &mut ctx.get::<JsBuffer>(0)?.into_value()?; // &mut [u8]
+  buf[0] = 1;
+  buf[1] = 2;
+  ctx.env.get_undefined()
+}
+```
+
+```js
+setBuffer(Buffer.from([0, 1])) // <Buffer 01 02>
+```
+
+## `JsSymbol`
+
+Representa um valor `Symbol` em JavaScript. Você pode criar um `JsSymbol` a partir de `&str` ou `JsString`.
+
+```rust
+// Criar a partir de &str
+#[js_function(1)]
+fn create_symbol(ctx: CallContext) -> Result<JsSymbol> {
+  let desc = ctx.get::<JsString>(0)?.into_utf8()?;
+  ctx.env.create_symbol(Some(desc.as_str()?))
+}
+```
+
+```rust
+// Criar a partir de JsString
+#[js_function(1)]
+fn create_symbol(ctx: CallContext) -> Result<JsSymbol> {
+  let desc = ctx.get::<JsString>(0)?;
+  ctx.env.create_symbol_from_js_string(desc)
+}
+```
+
+## `JsObject`
+
+Representa um valor `Object` em JavaScript. Existem muitas API's relacionadas a objetos em `JsObject`. Veja a [documentação](https://docs.rs/napi/latest/napi/struct.JsObject.html).
+
+```rust
+#[js_function(1)]
+fn set_bar(ctx: CallContext) -> Result<JsUndefined> {
+  let mut obj = ctx.get::<JsObject>(0)?;
+  let bar: JsString = obj.get_named_property("bar")?;
+  let bar_str = bar.into_utf8()?;
+  obj.set_named_property("bar", ctx.env.create_string_from_std(format!("{} bar", bar_str.as_str()?)))?;
+  ctx.env.get_undefined()
+}
+```
+
+```js
+setBar({ bar: 'bar' }) // { bar: "bar bar" }
+```
+
+## `JsDate`
+
+Representa um objeto `Date` em JavaScript. Os objetos `Date` JavaScript são descritos na [Seção 20.3](https://tc39.es/ecma262/#sec-date-objects) da Especificação da Linguagem ECMAScript.
+
+## `JsBigint`
+
+Representa um valor `Bigint` em JavaScript.
+
+## `JsExternal`
+
+Esta API aloca um valor JavaScript com dados externos anexados a ele. Isso é usado para passar dados externos através do código JavaScript, para que possam ser recuperados posteriormente pelo código nativo usando [`Env::get_value_external`](https://docs.rs/napi/latest/napi/struct.Env.html#method.get_value_external).

--- a/pages/docs/compat-mode/concepts/ref.pt-BR.mdx
+++ b/pages/docs/compat-mode/concepts/ref.pt-BR.mdx
@@ -1,0 +1,93 @@
+---
+description: Create object reference and make it live longer than it would be.
+---
+
+# Reference
+
+`Ref` é muito similar a `Rc` em Rust. No entanto, ele não diminuirá a contagem de referência quando descartado, você precisa chamar o método `unref` manualmente.
+
+{/* 在某些场景下，你可能需要手动延长某些 JavaScript 对象的 lifetime，防止他们过早的被 GC 回收掉。与在 JavaScript 中使用 Object 不一样，在 Rust 中保存一个 JsObject 的引用或者值对 Node.js 的 GC 系统而言是不透明的，也就是说 GC 并不知道你还存着一个 Object 的值想以后某个时候使用，GC 会在它认为合适的时候无情的回收他。这个时候我们需要为这个对象创建一个 *Reference*，相当于告诉 Node.js 的 GC 系统: hey 这个对象我还有用，你先不要回收他。 */}
+
+Em alguns cenários, você pode precisar estender manualmente a vida útil de certos objetos JavaScript para evitar que sejam recolhidos pelo GC prematuramente. Ao contrário de usar objetos em JavaScript, manter uma referência ou valor de um `JsObject` em Rust é opaco para o sistema de GC do Node.js, o que significa que o GC não sabe que você ainda tem um valor de objeto que deseja usar em algum momento futuro. O GC o reciclará impiedosamente quando achar adequado. Neste ponto, precisamos criar uma _Reference_ para este objeto, o que equivale a dizer ao sistema de GC do Node.js: ei, eu ainda preciso deste objeto, não o recicle ainda.
+
+{/* 我们通常是在进行一些异步操作的时候需要手动延长 Object 的 lifetime，比如在 `Task` 或者 `ThreadSafeFunction` 中存储一些对象的值。这些对象在函数执行完成之后不能被销毁，需要等到异步任务执行完成之后再手动调用 `unref` 方法来告诉 GC 我们已经不需要这个 Object 了。 */}
+
+Normalmente, precisamos estender manualmente a vida útil de um objeto ao realizar algumas operações assíncronas, como armazenar o valor de algum objeto em `Task` ou `ThreadSafeFunction`. Esses objetos não podem ser destruídos após a execução da função, então precisamos esperar até que a tarefa assíncrona termine de executar e, em seguida, chamar manualmente o método `unref` para informar ao GC que não precisamos mais do objeto.
+
+```rust
+
+struct Hash(Ref<JsBufferValue>);
+
+impl Task for Hash {
+  type Output = String;
+  type JsValue = JsString;
+
+  fn compute(&mut self) -> Result<Self::Output> {
+    Ok(base64(&self.0))
+  }
+
+  fn resolve(self, env: Env, output: Self::Output) -> Result<Self::JsValue> {
+    let result = env.create_string_from_std(output);
+    self.0.unref(env)?;
+    result
+  }
+}
+
+#[js_function(1)]
+// return Promise Object
+fn async_hash(ctx: CallContext) -> Result<JsObject> {
+  let input_data = ctx.get::<JsBuffer>(0)?.into_ref()?;
+  let hash = Hash(input_data);
+  ctx.env.spawn(hash).map(|async_task| async_task.promise_object())
+}
+
+fn base64(data: &[u8]) -> String {
+  todo!();
+}
+```
+
+```js
+asyncHash(Buffer::from([1, 2])).then((result) => {
+  console.log(result) // 0102
+})
+```
+
+Para objetos JavaScript que não sejam `JsBuffer`, você pode usar `Env::create_reference` para criar referências para eles e recuperar esses objetos JavaScript posteriormente com `Env::get_reference_value`. Por exemplo:
+
+```rust
+struct CallbackContext {
+  callback: Ref<()>
+}
+
+#[napi]
+pub fn wrap_in_obj(env: Env, js_fn: JsFunction) -> Result<JsObject> {
+  let mut js_obj = env.create_object()?;
+  // cria uma reference para a função javascript
+  let js_fn_ref = env.create_reference(js_fn)?;
+  let ctx = CallbackContext {
+    callback: js_fn_ref,
+  };
+  // faz o wrap em um object
+  env.wrap(&mut js_obj, ctx)?;
+  Ok(js_obj)
+}
+
+#[napi]
+pub fn call_wrapped_fn(env: Env, js_obj: JsObject) -> Result<()> {
+  let ctx: &mut CallbackContext = env.unwrap(&js_obj)?;
+  let js_fn: JsFunction = env.get_reference_value(&ctx.callback)?;
+  // a função javascript não deve ser recuperada antes de chamarmos Ref::unref()
+  js_fn.call_without_args(None)?;
+  Ok(())
+}
+```
+
+```js
+const logSomething = () => {
+  console.log('hello')
+}
+const obj = wrapInObj(logSomething)
+callWrappedFn(obj) // log 'hello'
+```
+
+Você sempre deve obter objetos JavaScript de referências em vez de armazenar esses objetos JavaScript diretamente. `JsValue` referenciados ainda podem se tornar inválidos após algum tempo.

--- a/pages/docs/compat-mode/concepts/thread-safe-function.pt-BR.mdx
+++ b/pages/docs/compat-mode/concepts/thread-safe-function.pt-BR.mdx
@@ -1,0 +1,51 @@
+---
+description: Using thread safe function to interactive with native thread.
+---
+
+# Thread safe function
+
+> As funções JavaScript normalmente só podem ser chamadas a partir da thread principal de um addon nativo. Se um addon cria threads adicionais, então as funções N-API que requerem um `Env`, `JsValue`, ou `Ref` não devem ser chamadas a partir dessas threads. <br/>
+> Quando um addon tem threads adicionais e as funções JavaScript precisam ser invocadas com base no processamento concluído por essas threads, essas threads devem se comunicar com a thread principal do addon para que ela possa invocar a função JavaScript em nome delas. As APIs de funções thread-safe fornecem uma maneira fácil de fazer isso. <br/>
+> Essas APIs fornecem o tipo `ThreadSafeFunction`, bem como APIs para criar, destruir e chamar objetos desse tipo. `Env::create_threadsafe_function` cria uma referência persistente para uma `JsFunction` que contém uma função JavaScript que pode ser chamada de várias threads. As chamadas ocorrem de forma assíncrona. Isso significa que os valores com os quais o retorno de chamada JavaScript deve ser chamado serão colocados em uma fila e, para cada valor na fila, uma chamada eventualmente será feita para a função JavaScript. <br />
+> Após a criação de uma `ThreadSafeFunction`, um retorno de chamada `Finalize`pode ser fornecido. Esse retorno de chamada será invocado na thread principal quando a função thread-safe estiver prestes a ser destruída. Ele recebe o contexto e os dados de finalização fornecidos durante a construção e fornece uma oportunidade para limpar após as threads, por exemplo, chamando `uv_thread_join()`. Além da thread do loop principal, nenhuma thread deve estar usando a função thread-safe após a conclusão do retorno de chamada de finalização.
+
+```rust
+#[js_function(1)]
+pub fn test_threadsafe_function(ctx: CallContext) -> Result<JsUndefined> {
+  let func = ctx.get::<JsFunction>(0)?;
+
+  let tsfn =
+    ctx
+      .env
+      .create_threadsafe_function(&func, 0, |ctx: ThreadSafeCallContext<Vec<u32>>| {
+        ctx
+          .value
+          .iter()
+          .map(|v| ctx.env.create_uint32(*v))
+          .collect::<Result<Vec<JsNumber>>>()
+      })?;
+
+  let tsfn_cloned = tsfn.clone();
+
+  thread::spawn(move || {
+    let output: Vec<u32> = vec![0, 1, 2, 3];
+    // Está tudo bem em chamar uma função thread-safe várias vezes.
+    tsfn.call(Ok(output.clone()), ThreadsafeFunctionCallMode::Blocking);
+  });
+
+  thread::spawn(move || {
+    let output: Vec<u32> = vec![3, 2, 1, 0];
+    // Está tudo bem em chamar uma função thread-safe várias vezes.
+    tsfn_cloned.call(Ok(output.clone()), ThreadsafeFunctionCallMode::NonBlocking);
+  });
+
+  ctx.env.get_undefined()
+}
+```
+
+```js
+testThreadsafeFunction((err, ...values) => {
+  console.log(err) // null
+  console.log(values) // [0, 1, 2, 3] and [3, 2, 1, 0]
+})
+```

--- a/pages/docs/compat-mode/concepts/tokio.pt-BR.mdx
+++ b/pages/docs/compat-mode/concepts/tokio.pt-BR.mdx
@@ -1,0 +1,36 @@
+---
+description: Running tokio task with build-in tokio runtime.
+---
+
+# Tokio
+
+[Exemplo do mundo real](https://github.com/napi-rs/napi-rs/blob/main/examples/napi-compat-mode/src/tokio_rt/read_file.rs)
+
+Você também pode executar `Tokio` futures no Node.js. Com o recurso `tokio_rt`, o `napi-rs` criará um runtime do tokio para que você possa usar `Env::execute_tokio_future` para executar um futuro e retornar uma `Promise` JavaScript.
+
+> `tokio_rt` precisa da `ThreadSafeFunction` por baixo dos panos, então habilitar o recurso `tokio_rt` ativará `napi4` por padrão.
+
+```rust
+#[js_function(1)]
+pub fn readfile(ctx: CallContext) -> Result<JsObject> {
+  let js_filepath = ctx.get::<JsString>(0)?;
+  let path_str = js_filepath.into_utf8()?.into_owned()?;
+  ctx.env.execute_tokio_future(
+    tokio::fs::read(path_str).map(|v| {
+      v.map_err(|e| {
+        Error::new(
+          Status::GenericFailure,
+          format!("failed to read file, {}", e),
+        )
+      })
+    }),
+    |&mut env, data| env.create_buffer_with_data(data).map(|v| v.into_raw()),
+  )
+}
+```
+
+```js
+readfile('./test.txt').then((data) => {
+  console.log(data) // Buffer<00 03 ...>
+})
+```

--- a/pages/docs/compat-mode/concepts/wrap.pt-BR.mdx
+++ b/pages/docs/compat-mode/concepts/wrap.pt-BR.mdx
@@ -1,0 +1,43 @@
+---
+description: Attach native object to existed JsObject.
+---
+
+# Wrap native object
+
+Encapsula(wrap) uma instância nativa em um objeto JavaScript. A instância nativa pode ser recuperada posteriormente usando `Env::unwrap`.
+
+```rust
+struct Native {
+  value: i32,
+}
+
+#[js_function(1)]
+fn attach_native_object(ctx: CallContext) -> Result<JsUndefined> {
+  let count: i32 = ctx.get::<JsNumber>(0)?.try_into()?;
+  let mut this: JsObject = ctx.this_unchecked();
+  ctx
+    .env
+    .wrap(&mut this, Native { value: count + 100 })?;
+  ctx.env.get_undefined()
+}
+
+#[js_function(1)]
+fn get_native_object(ctx: CallContext) -> Result<JsNumber> {
+  let count: i32 = ctx.get::<JsNumber>(0)?.try_into()?;
+  let mut this: JsObject = ctx.this_unchecked();
+  let native: Native = ctx
+    .env
+    .unwrap(&mut this)?;
+  ctx.env.create_int32(native.value + 1)
+}
+```
+
+```js
+const obj = {
+  attach: attachNativeObject,
+  get: getNativeObject,
+}
+
+obj.attach(100)
+obj.get() // 101
+```

--- a/pages/docs/compat-mode/recipes/_meta.pt-BR.json
+++ b/pages/docs/compat-mode/recipes/_meta.pt-BR.json
@@ -1,0 +1,5 @@
+{
+  "call-context": "CallContext",
+  "define-class": "Definindo Classe",
+  "registering-module": "Registrando Módulo"
+}

--- a/pages/docs/compat-mode/recipes/call-context.pt-BR.mdx
+++ b/pages/docs/compat-mode/recipes/call-context.pt-BR.mdx
@@ -1,0 +1,84 @@
+---
+description: Call context in JsFunction.
+---
+
+# CallContext
+
+`CallContext` contém todas as informações em uma chamada de função JavaScript.
+
+## Arguments
+
+Você pode obter o argumento JavaScript através do método `CallContext::get(usize)`:
+
+```rust
+#[js_function(1)]
+fn hey(ctx: CallContext) -> Result<JsUndefined> {
+  let arg1: JsString = ctx.get(0)?;
+  ctx.env.get_undefined()
+}
+```
+
+A sequência de argumentos começa em `0`, e não pode ser maior do que o número passado na macro `js_function`. Se você passar um índice maior do que o número na macro `js_function`, um erro JavaScript será lançado.
+
+O tipo do resultado deve ser igual ao tipo real do argumento, ou um erro de tipo será lançado.
+
+```rust
+struct Native {
+  value: i32,
+}
+
+#[js_function(1)]
+fn attach_native_object(ctx: CallContext) -> Result<JsUndefined> {
+  let count: i32 = ctx.get::<JsNumber>(0)?.try_into()?;
+  let mut this: JsObject = ctx.this_unchecked();
+  ctx
+    .env
+    .wrap(&mut this, Native { value: count + 100 })?;
+  ctx.env.get_undefined()
+}
+
+#[js_function(1)]
+fn get_native_object(ctx: CallContext) -> Result<JsNumber> {
+  let count: i32 = ctx.get::<JsNumber>(0)?.try_into()?;
+  let mut this: JsObject = ctx.this_unchecked();
+  let native: Native = ctx
+    .env
+    .unrwap(&mut this)?;
+  ctx.env.create_int32(native.value + 1)
+}
+```
+
+```js
+const obj = {
+  attach: attachNativeObject,
+  get: getNativeObject,
+}
+
+obj.attach(100)
+obj.get() // 101
+```
+
+## Argument length
+
+O número que foi passado para `js_function` é a capacidade do Array de argumentos, o tamanho real dos argumentos pode ser obtido com `CallContext::length`.
+
+```rust
+#[js_function(100)]
+fn hey(ctx: CallContext) -> Result<JsUndefined> {
+  println!("{}", ctx.length);
+  ctx.env.get_undefined()
+}
+```
+
+```js
+hey() // 0
+hey({}) // 1
+```
+
+## This
+
+Você pode obter this object através de `CallContext::this` ou `CallContext::this_unchecked`. A única diferença entre os dois métodos é que `CallContext::this` fará uma verificação de tipo; se o tipo fornecido não corresponder ao `this`, um erro `InvalidArg` será lançado.
+
+## new target
+
+Se a função foi chamada pelo operador `new`, você pode usar `CallContext::get_new_target` para obter o novo destino dessa função construtora.

--- a/pages/docs/compat-mode/recipes/define-class.pt-BR.mdx
+++ b/pages/docs/compat-mode/recipes/define-class.pt-BR.mdx
@@ -1,0 +1,70 @@
+---
+description: Defining a JavaScript class in Rust.
+---
+
+# Definindo Classe
+
+[Exemplo do mundo real](https://github.com/Brooooooklyn/skia-rs/blob/main/src/ctx.rs#L30)
+
+Este exemplo cria uma classe chamada `TestClass` que possui uma propriedade JavaScript chamada `count` e envolve uma struct Rust chamada `NativeClass` na instância do objeto, que possui uma propriedade `value`. Os métodos podem acessar tanto as propriedades do objeto quanto a struct envolvida.
+
+```rust filename="lib.rs"
+#[macro_use]
+extern crate napi_derive;
+
+use std::convert::TryInto;
+use napi::{CallContext, JsNumber, JsObject, JsUndefined, Property, Result, Env};
+
+struct NativeClass {
+  value: i32,
+}
+
+#[js_function(1)]
+fn test_class_constructor(ctx: CallContext) -> Result<JsUndefined> {
+  let count: i32 = ctx.get::<JsNumber>(0)?.try_into()?;
+  let mut this: JsObject = ctx.this_unchecked();
+  ctx
+    .env
+    .wrap(&mut this, NativeClass { value: count + 100 })?;
+  this.set_named_property("count", ctx.env.create_int32(count)?)?;
+  ctx.env.get_undefined()
+}
+
+#[js_function(1)]
+fn add_count(ctx: CallContext) -> Result<JsNumber> {
+  let add: i32 = ctx.get::<JsNumber>(0)?.try_into()?;
+  let mut this: JsObject = ctx.this_unchecked();
+  let count: i32 = this.get_named_property::<JsNumber>("count")?.try_into()?;
+  this.set_named_property("count", ctx.env.create_int32(count + add)?)?;
+  this.get_named_property("count")
+}
+
+#[js_function(1)]
+fn add_native_count(ctx: CallContext) -> Result<JsNumber> {
+  let add: i32 = ctx.get::<JsNumber>(0)?.try_into()?;
+  let this: JsObject = ctx.this_unchecked();
+  let native_class: &mut NativeClass = ctx.env.unwrap(&this)?;
+  native_class.value += add;
+  ctx.env.create_int32(native_class.value)
+}
+
+#[module_exports]
+pub fn init(mut exports: JsObject, env: Env) -> Result<()> {
+  let test_class = env
+    .define_class("TestClass", test_class_constructor, &[
+      Property::new(&env, "addCount")?.with_method(add_count),
+      Property::new(&env, "addNativeCount")?.with_method(add_native_count),
+    ])?;
+  exports.set_named_property("TestClass", test_class)?;
+
+  Ok(())
+}
+```
+
+```js
+const { TestClass } = require('./index.node')
+
+const test = new TestClass(100)
+
+test.addCount()
+```

--- a/pages/docs/compat-mode/recipes/registering-module.pt-BR.mdx
+++ b/pages/docs/compat-mode/recipes/registering-module.pt-BR.mdx
@@ -1,0 +1,54 @@
+---
+description: Registering Node.js module.
+---
+
+# Registrando Módulo
+
+Os módulos podem ser registrados pelo macro `module_exports`:
+
+```rust filename="lib.rs"
+#[macro_use]
+extern crate napi_derive;
+
+use napi::*;
+
+#[module_exports]
+fn init(mut exports: JsObject) -> Result<()> {
+  exports.create_named_method("hello", hello)?;
+
+  Ok(())
+}
+
+#[js_function]
+fn hello(ctx: CallContext) -> Result<JsString> {
+  todo!()
+}
+```
+
+Também pode haver um segundo argumento `Env`:
+
+```rust filename="lib.rs"
+#[macro_use]
+extern crate napi_derive;
+
+use napi::*;
+
+#[module_exports]
+fn init(mut exports: JsObject, env: Env) -> Result<()> {
+  exports.create_named_method("hello", hello)?;
+
+  exports.set_named_property("MAX_SAFE_SIZE", env.create_uint32(1000)?)?;
+
+  Ok(())
+}
+
+#[js_function]
+fn hello(ctx: CallContext) -> Result<JsString> {
+  todo!()
+}
+```
+
+```js
+const native = require('./index.node')
+console.log(native.MAX_SAFE_SIZE) // 1000
+```

--- a/pages/docs/concepts/_meta.pt-BR.json
+++ b/pages/docs/concepts/_meta.pt-BR.json
@@ -1,0 +1,19 @@
+{
+  "exports": "Exports",
+  "naming-conventions": "Naming conventions",
+  "values": "Values",
+  "class": "Class",
+  "enum": "Enum",
+  "object": "Object",
+  "function": "Function",
+  "threadsafe-function": "ThreadsafeFunction",
+  "async-task": "AsyncTask",
+  "inject-env": "Inject Env",
+  "inject-this": "Inject This",
+  "reference": "Reference",
+  "async-fn": "async fn",
+  "external": "External",
+  "await-promise": "Await Promise",
+  "types-overwrite": "Sobrescrita de Tipos",
+  "typed-array": "Typed Array"
+}

--- a/pages/docs/concepts/async-fn.pt-BR.mdx
+++ b/pages/docs/concepts/async-fn.pt-BR.mdx
@@ -1,0 +1,46 @@
+---
+description: Run a Rust async fn with the tokio runtime.
+---
+
+import { Callout } from 'nextra-theme-docs'
+
+# async fn
+
+<Callout>
+Você deve habilitar o recurso ***async*** ou ***tokio_rt*** no `napi` para usar `async fn`:
+
+```toml {3} filename="Cargo.toml"
+[dependencies]
+napi = { version = "2", features = ["async"] }
+```
+
+</Callout>
+
+Você pode realizar muitos trabalhos async/multi-threaded com `AsyncTask` e `ThreadsafeFunction`, mas às vezes você pode querer usar diretamente as crates do ecossistema async do Rust.
+
+**NAPI-RS** suporta o runtime do `tokio` por padrão. Se você `await` um `future` do tokio em uma `async fn`, **NAPI-RS** o executará no runtime do tokio e o converterá em uma `Promise` do JavaScript.
+
+```rust {6} filename="lib.rs"
+use futures::prelude::*;
+use napi::bindgen_prelude::*;
+use tokio::fs;
+
+#[napi]
+async fn read_file_async(path: String) -> Result<Buffer> {
+  fs::read(path)
+    .map(|r| match r {
+      Ok(content) => Ok(content.into()),
+      Err(e) => Err(Error::new(
+        Status::GenericFailure,
+        format!("failed to read file, {}", e),
+      )),
+    })
+    .await
+}
+```
+
+⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️
+
+```ts filename="index.d.ts"
+export function readFileAsync(path: string): Promise<Buffer>
+```

--- a/pages/docs/concepts/async-task.pt-BR.mdx
+++ b/pages/docs/concepts/async-task.pt-BR.mdx
@@ -1,0 +1,201 @@
+---
+description: Run a task in the libuv thread pool and abort it with AbortSignal.
+---
+
+# AsyncTask
+
+Precisamos falar sobre `Task` antes de falar sobre `AsyncTask`.
+
+## `Task`
+
+Os módulos de complemento geralmente precisam aproveitar os ajudantes assíncronos do libuv como parte de sua implementação. Isso lhes permite agendar o trabalho para ser executado de forma assíncrona, para que seus métodos possam retornar antecipadamente antes que o trabalho seja concluído. Isso permite evitar o bloqueio da execução geral da aplicação Node.js.
+
+O trait `Task` fornece uma maneira de definir uma tarefa assíncrona que precisa ser executada na thread do libuv. Você pode implementar o método `compute` , que será chamado na thread do libuv.
+
+```rust {11-13} filename="lib.rs"
+use napi::{Task, Env, Result, JsNumber};
+
+struct AsyncFib {
+  input: u32,
+}
+
+impl Task for AsyncFib {
+  type Output = u32;
+  type JsValue = JsNumber;
+
+  fn compute(&mut self) -> Result<Self::Output> {
+    Ok(fib(self.input))
+  }
+
+  fn resolve(&mut self, env: Env, output: u32) -> Result<Self::JsValue> {
+    env.create_uint32(output)
+  }
+}
+```
+
+`fn compute` é executado na thread do libuv, você pode executar algum cálculo pesado aqui, o que não bloqueará a thread JavaScript principal.
+
+Você pode notar que existem dois tipos associados no trait `Task`. O `type Output` e o `type JsValue`. `Output` é o tipo de retorno do método `compute`. `JsValue` é o tipo de retorno do método `resolve`.
+
+import { Callout } from 'nextra-theme-docs'
+
+<Callout>
+  Precisamos de `type Output` e `type JsValue` separados porque não podemos
+  chamar a função JavaScript de volta em `fn compute`, pois ela não é executada
+  na thread principal. Portanto, precisamos de `fn resolve`, que é executado na
+  thread principal, para criar o `JsValue` a partir de `Output` e `Env` e
+  chamá-lo de volta em JavaScript.
+</Callout>
+
+Você pode usar a API de baixo nível `Env::spawn` para iniciar uma `Task` definida no pool de threads libuv. Veja um exemplo na [Referência](../compat-mode/concepts/ref).
+
+Além de `compute` e `resolve`, você também pode fornecer o método `reject` para fazer alguma limpeza quando a `Task` apresenta erro, como `unref` algum objeto:
+
+```rust {28} filename="lib.rs"
+struct CountBufferLength {
+  data: Ref<JsBufferValue>,
+}
+
+impl CountBufferLength {
+  pub fn new(data: Ref<JsBufferValue>) -> Self {
+    Self { data }
+  }
+}
+
+impl Task for CountBufferLength {
+  type Output = usize;
+  type JsValue = JsNumber;
+
+  fn compute(&mut self) -> Result<Self::Output> {
+    if self.data.len() == 10 {
+      return Err(Error::from_reason("len can't be 10".to_string()));
+    }
+    Ok((&self.data).len())
+  }
+
+  fn resolve(&mut self, env: Env, output: Self::Output) -> Result<Self::JsValue> {
+    self.data.unref(env)?;
+    env.create_uint32(output as _)
+  }
+
+  fn reject(&mut self, env: Env, err: Error) -> Result<Self::JsValue> {
+    self.data.unref(env)?;
+    Err(err)
+  }
+}
+```
+
+Você também pode fornecer um método `finally` para fazer algo depois que a `Task` for `resolved` ou `rejected`:
+
+```rust {27} filename="lib.rs"
+struct CountBufferLength {
+  data: Ref<JsBufferValue>,
+}
+
+impl CountBufferLength {
+  pub fn new(data: Ref<JsBufferValue>) -> Self {
+    Self { data }
+  }
+}
+
+#[napi]
+impl Task for CountBufferLength {
+  type Output = usize;
+  type JsValue = JsNumber;
+
+  fn compute(&mut self) -> Result<Self::Output> {
+    if self.data.len() == 10 {
+      return Err(Error::from_reason("len can't be 5".to_string()));
+    }
+    Ok((&self.data).len())
+  }
+
+  fn resolve(&mut self, env: Env, output: Self::Output) -> Result<Self::JsValue> {
+    env.create_uint32(output as _)
+  }
+
+  fn finally(&mut self, env: Env) -> Result<()> {
+    self.data.unref(env)?;
+    Ok(())
+  }
+}
+```
+
+<Callout>
+O `#[napi]` macro acima do `impl Task for AsyncFib` é apenas para a geração do `.d.ts`. Se nenhum `#[napi]` for definido aqui, o tipo TypeScript gerado para a `AsyncTask` retornada será `Promise<unknown>`.
+</Callout>
+
+## `AsyncTask`
+
+A `Task` que você define não pode ser retornada diretamente para JavaScript, o mecanismo do JavaScript não sabe como executar e resolver o valor da sua `struct`. `AsyncTask` é um wrapper de `Task` que pode ser retornado ao mecanismo do JavaScript. Ele pode ser criado com `Task` e um opcional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal).
+
+```rust filename="lib.rs"
+#[napi]
+fn async_fib(input: u32) -> AsyncTask<AsyncFib> {
+  AsyncTask::new(AsyncFib { input })
+}
+```
+
+⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️
+
+```ts filename="index.d.ts"
+export function asyncFib(input: number) => Promise<number>
+```
+
+### Criar `AsyncTask` com `AbortSignal`
+
+Em alguns cenários, pode ser desejável interromper a `AsyncTask`, na fila, por exemplo, usando `debounce` em algumas tarefas de cálculo. Você pode fornecer um `AbortSignal` para a `AsyncTask`, para que possa interromper a `AsyncTask` se ainda não tiver sido iniciada.
+
+```rust {4} filename="lib.rs"
+use napi::bindgen_prelude::AbortSignal;
+
+#[napi]
+fn async_fib(input: u32, signal: AbortSignal) -> AsyncTask<AsyncFib> {
+  AsyncTask::with_signal(AsyncFib { input }, signal)
+}
+```
+
+⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️
+
+```ts filename="index.d.ts"
+export function asyncFib(input: number, signal: AbortSignal) => Promise<number>
+```
+
+Se você chamar `AbortController.abort` no código JavaScript e a `AsyncTask` ainda não tiver sido iniciada, a `AsyncTask` será abortada imediatamente e rejeitada com `AbortError`.
+
+```js {6} filename="test.mjs"
+import { asyncFib } from './index.js'
+
+const controller = new AbortController()
+
+asyncFib(20, controller.signal).catch((e) => {
+  console.error(e) // Error: AbortError
+})
+
+controller.abort()
+```
+
+Você também pode fornecer `Option<AbortSignal>` para `AsyncTask` se não souber se a `AsyncTask` precisa ser abortada:
+
+```rust filename="lib.rs"
+use napi::bindgen_prelude::AbortSignal;
+
+#[napi]
+fn async_fib(input: u32, signal: Option<AbortSignal>) -> AsyncTask<AsyncFib> {
+  AsyncTask::with_optional_signal(AsyncFib { input }, signal)
+}
+```
+
+⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️
+
+```ts filename="index.d.ts"
+export function asyncFib(
+  input: number,
+  signal?: AbortSignal | undefined | null,
+): Promise<number>
+```
+
+<Callout>
+  Caso a `AsyncTask` já tenha sido iniciada ou concluída, o
+  `AbortController.abort` não terá efeito.
+</Callout>

--- a/pages/docs/concepts/await-promise.pt-BR.mdx
+++ b/pages/docs/concepts/await-promise.pt-BR.mdx
@@ -1,0 +1,37 @@
+---
+description: Await a JavaScript Promise in Rust.
+---
+
+# Await Promise
+
+Aguardar uma `Promise` JavaScript em Rust parece loucura, mas é viável em **NAPI-RS**.
+
+import { Callout } from 'nextra-theme-docs'
+
+<Callout>
+  Aguardar uma `Promise` JavaScript requer que os recursos `tokio_rt` e `napi4`
+  estejam habilitados.
+</Callout>
+
+```rust filename="lib.rs"
+use napi::bindgen_prelude::*;
+
+#[napi]
+pub async fn async_plus_100(p: Promise<u32>) -> Result<u32> {
+  let v = p.await?;
+  Ok(v + 100)
+}
+```
+
+```js {4} filename="test.mjs"
+import { asyncPlus100 } from './index.js'
+
+const fx = 20
+const result = await asyncPlus100(
+  new Promise((resolve) => {
+    setTimeout(() => resolve(fx), 50)
+  }),
+)
+
+console.log(result) // 120
+```

--- a/pages/docs/concepts/class.pt-BR.mdx
+++ b/pages/docs/concepts/class.pt-BR.mdx
@@ -1,0 +1,375 @@
+---
+title: 'Class'
+---
+
+# Classe
+
+import { Callout } from 'nextra-theme-docs'
+
+<Callout>
+  Não há o conceito de classe em Rust. Utilizamos `struct` para representar uma
+  `Class` JavaScript.
+</Callout>
+
+## `Constructor`
+
+### `constructor` padrão
+
+Se todos os campos em uma struct `Rust` forem `pub`, então você pode usar `#[napi(constructor)]` para fazer com que a `struct` tenha um `constructor` padrão.
+
+```rust filename="lib.rs"
+#[napi(constructor)]
+pub struct AnimalWithDefaultConstructor {
+  pub name: String,
+  pub kind: u32,
+}
+```
+
+```ts filename="index.d.ts"
+export class AnimalWithDefaultConstructor {
+  name: string
+  kind: number
+  constructor(name: string, kind: number)
+}
+```
+
+### `constructor` personalizado
+
+Se você quiser definir um `constructor` personalizado, pode usar `#[napi(constructor)]` na sua constructor `fn` no bloco `impl` da struct.
+
+```rust filename="lib.rs"
+// Uma estrutura complexa que não pode ser exposta diretamente ao JavaScript.
+pub struct QueryEngine {}
+
+#[napi(js_name = "QueryEngine")]
+pub struct JsQueryEngine {
+  engine: QueryEngine,
+}
+
+#[napi]
+impl JsQueryEngine {
+  #[napi(constructor)]
+  pub fn new() -> Self {
+    JsQueryEngine { engine: QueryEngine::new() }
+  }
+}
+```
+
+```ts filename="index.d.ts"
+export class QueryEngine {
+  constructor()
+}
+```
+
+<Callout type="warning" emoji="⚠️">
+  **NAPI-RS** atualmente não suporta `private constructor`. Seu construtor
+  personalizado deve ser `pub` em Rust.
+</Callout>
+
+## Factory
+
+Além do `constructor`, você também pode definir métodos de fábrica na `Class` usando `#[napi(factory)]`.
+
+```rust filename="lib.rs"
+// Uma estrutura complexa que não pode ser exposta diretamente ao JavaScript.
+pub struct QueryEngine {}
+
+#[napi(js_name = "QueryEngine")]
+pub struct JsQueryEngine {
+  engine: QueryEngine,
+}
+
+#[napi]
+impl JsQueryEngine {
+  #[napi(factory)]
+  pub fn with_initial_count(count: u32) -> Self {
+    JsQueryEngine { engine: QueryEngine::with_initial_count(count) }
+  }
+}
+```
+
+```ts filename="index.d.ts"
+export class QueryEngine {
+  static withInitialCount(count: number): QueryEngine
+  constructor()
+}
+```
+
+<Callout type="warning" emoji="⚠️">
+  Se nenhum `#[napi(constructor)]` for definido na `struct`, e você tentar criar
+  uma instância (`new`) da `Class` em JavaScript, um erro será lançado.
+</Callout>
+
+```js {3} filename="test.mjs"
+import { QueryEngine } from './index.js'
+
+new QueryEngine() // Error: Class contains no `constructor`, cannot create it!
+```
+
+## `class method`
+
+Você pode definir um método de classe JavaScript com `#[napi]` em um método de struct em **Rust**.
+
+```rust filename="lib.rs"
+// Uma estrutura complexa que não pode ser exposta diretamente ao JavaScript.
+pub struct QueryEngine {}
+
+#[napi(js_name = "QueryEngine")]
+pub struct JsQueryEngine {
+  engine: QueryEngine,
+}
+
+#[napi]
+impl JsQueryEngine {
+  #[napi(factory)]
+  pub fn with_initial_count(count: u32) -> Self {
+    JsQueryEngine { engine: QueryEngine::with_initial_count(count) }
+  }
+
+  /// Class method (Método de classe)
+  #[napi]
+  pub async fn query(&self, query: String) -> napi::Result<String> {
+    self.engine.query(query).await
+  }
+
+  #[napi]
+  pub fn status(&self) -> napi::Result<u32> {
+    self.engine.status()
+  }
+}
+```
+
+```ts filename="index.d.ts"
+export class QueryEngine {
+  static withInitialCount(count: number): QueryEngine
+  constructor()
+  query(query: string) => Promise<string>
+  status() => number
+}
+```
+
+<Callout type="warning" emoji="⚠️">
+  `async fn` precisa dos recursos `napi4` e `tokio_rt` habilitados.
+</Callout>
+
+<Callout>
+Qualquer  `fn` em `Rust` que retorne `Result<T>` será tratado como `T` em JavaScript/TypeScript. Se o `Result<T>` for `Err`, um erro JavaScript será lançado.
+</Callout>
+
+## `Getter`
+
+Defina [um `getter` de classe JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get) usando `#[napi(getter)]`. A `fn` Rust deve ser um método de struct, não uma função associada.
+
+```rust {22-25} filename="lib.rs"
+// Uma estrutura complexa que não pode ser exposta diretamente ao JavaScript.
+pub struct QueryEngine {}
+
+#[napi(js_name = "QueryEngine")]
+pub struct JsQueryEngine {
+  engine: QueryEngine,
+}
+
+#[napi]
+impl JsQueryEngine {
+  #[napi(factory)]
+  pub fn with_initial_count(count: u32) -> Self {
+    JsQueryEngine { engine: QueryEngine::with_initial_count(count) }
+  }
+
+  /// Método de classe
+  #[napi]
+  pub async fn query(&self, query: String) -> napi::Result<String> {
+    self.engine.query(query).await
+  }
+
+  #[napi(getter)]
+  pub fn status(&self) -> napi::Result<u32> {
+    self.engine.status()
+  }
+}
+```
+
+```ts {4} filename="index.d.ts"
+export class QueryEngine {
+  static withInitialCount(count: number): QueryEngine
+  constructor()
+  get status(): number
+}
+```
+
+## `Setter`
+
+Defina [`setter` de classe JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set) usando `#[napi(setter)]`. A `fn` Rust deve ser um método de struct, não uma função associada.
+
+```rust {27-30} filename="lib.rs"
+// Uma estrutura complexa que não pode ser exposta diretamente ao JavaScript.
+pub struct QueryEngine {}
+
+#[napi(js_name = "QueryEngine")]
+pub struct JsQueryEngine {
+  engine: QueryEngine,
+}
+
+#[napi]
+impl JsQueryEngine {
+  #[napi(factory)]
+  pub fn with_initial_count(count: u32) -> Self {
+    JsQueryEngine { engine: QueryEngine::with_initial_count(count) }
+  }
+
+  /// Método de classe
+  #[napi]
+  pub async fn query(&self, query: String) -> napi::Result<String> {
+    self.engine.query(query).await
+  }
+
+  #[napi(getter)]
+  pub fn status(&self) -> napi::Result<u32> {
+    self.engine.status()
+  }
+
+  #[napi(setter)]
+  pub fn count(&mut self, count: u32) {
+    self.engine.count = count;
+  }
+}
+```
+
+```ts {5} filename="index.d.ts"
+export class QueryEngine {
+  static withInitialCount(count: number): QueryEngine
+  constructor()
+  get status(): number
+  set count(count: number)
+}
+```
+
+## Class como argumento
+
+`Class` é diferente de [`Object`](./object). `Class` pode ter métodos Rust e funções associadas nele. Cada campo em `Class` pode ser mutado em JavaScript.
+
+Portanto a ownership(propriedade) da `Class` é realmente transferida para o lado do JavaScript enquanto você a está criando. Ela é gerenciada pelo GC do JavaScript e você só pode passá-la de volta passando sua `reference`.
+
+```rust {1,5} filename="lib.rs"
+pub fn accept_class(engine: &QueryEngine) {
+  // ...
+}
+
+pub fn accept_class_mut(engine: &mut QueryEngine) {
+  // ...
+}
+```
+
+```ts filename="index.d.ts"
+export function acceptClass(engine: QueryEngine): void
+export function acceptClassMut(engine: QueryEngine): void
+```
+
+## Atributos de propriedade
+
+Os atributos padrão da propriedade são `writable = true`, `enumerable = true` e `configurable = true`. Você pode controlar os atributos da propriedade através do macro `#[napi]`:
+
+```rust {20} filename="lib.rs"
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+
+// Uma estrutura complexa que não pode ser exposta diretamente ao JavaScript.
+#[napi]
+pub struct QueryEngine {
+  num: i32,
+}
+
+#[napi]
+impl QueryEngine {
+  #[napi(constructor)]
+  pub fn new() -> Result<Self> {
+    Ok(Self {
+      num: 42,
+    })
+  }
+
+  // writable / enumerable / configurable
+  #[napi(writable = false)]
+  pub fn get_num(&self) -> i32 {
+    self.num
+  }
+}
+```
+
+Neste caso, o método `getNum` de `QueryEngine` não é gravável:
+
+```js {4} filename="main.mjs"
+import { QueryEngine } from './index.js'
+
+const qe = new QueryEngine()
+qe.getNum = function () {} // TypeError: Cannot assign to read only property 'getNum' of object '#<QueryEngine>'
+```
+
+## Lógica de Finalização personalizada
+
+O NAPI-RS descartará a struct Rust envolvida no objeto JavaScript quando o objeto JavaScript for "garbage collected". Você também pode especificar uma lógica de finalização personalizada para a struct Rust.
+
+```rust {4, 26} filename="lib.rs"
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+
+#[napi(custom_finalize)]
+pub struct CustomFinalize {
+  width: u32,
+  height: u32,
+  inner: Vec<u8>,
+}
+
+#[napi]
+impl CustomFinalize {
+  #[napi(constructor)]
+  pub fn new(mut env: Env, width: u32, height: u32) -> Result<Self> {
+    let inner = vec![0; (width * height * 4) as usize];
+    let inner_size = inner.len();
+    env.adjust_external_memory(inner_size as i64)?;
+    Ok(Self {
+      width,
+      height,
+      inner,
+    })
+  }
+}
+
+impl ObjectFinalize for CustomFinalize {
+  fn finalize(self, mut env: Env) -> Result<()> {
+    env.adjust_external_memory(-(self.inner.len() as i64))?;
+    Ok(())
+  }
+}
+```
+
+Primeiro, você pode definir o atributo `custom_finalize` no macro `#[napi]`, e o NAPI-RS não gerará o `ObjectFinalize` padrão para a estrutura Rust.
+
+Então, você pode implementar o `ObjectFinalize` você mesmo para a Rust struct.
+
+Neste caso, a estrutura `CustomFinalize` aumenta a memória externa no **constructor** e a diminui em `fn finalize`.
+
+## `instance of`
+
+Há um `fn instance_of` em todas as classes `#[napi]`:
+
+```rust {9} filename="lib.rs"
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+
+#[napi]
+pub struct NativeClass {}
+
+#[napi]
+pub fn is_native_class_instance(env: Env, value: Unknown) -> Result<bool> {
+  NativeClass::instance_of(env, value)
+}
+```
+
+```js filename="main.mjs"
+import { NativeClass, isNativeClassInstance } from './index.js'
+
+const nc = new NativeClass()
+console.log(isNativeClassInstance(nc)) // true
+console.log(isNativeClassInstance(1)) // false
+```

--- a/pages/docs/concepts/enum.pt-BR.mdx
+++ b/pages/docs/concepts/enum.pt-BR.mdx
@@ -1,0 +1,59 @@
+---
+title: 'Enum'
+---
+
+# Enum
+
+import { Callout } from 'nextra-theme-docs'
+
+<Callout type="warning" emoji="⚠️">
+  Não há `enum` no JavaScript, e o `enum` em Rust é muito diferente do `enum` em
+  TypeScript. Você precisa ler esta seção cuidadosamente antes de usar `enum` do
+  Rust em JavaScript.
+</Callout>
+
+Em **NAPI-RS**, o `enum` do Rust é basicamente transformado em um simples objeto JavaScript.
+
+```rust filename="lib.rs"
+#[napi]
+enum Kind {
+  Duck,
+  Dog,
+  Cat,
+}
+```
+
+⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️
+
+```ts filename="index.d.ts"
+export const enum Kind {
+  Duck,
+  Dog,
+  Cat,
+}
+```
+
+Em `TypeScript`, os membros de `enums` numéricos também recebem um mapeamento reverso dos valores do enum para os nomes do enum. Mas em Rust, não temos esse comportamento de mapeamento reverso. É apenas um objeto JavaScript simples.
+
+## String enum
+
+```rust filename="lib.rs"
+#[napi(string_enum)]
+enum Kind {
+  Duck,
+  Dog,
+  Cat,
+}
+```
+
+⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️
+
+```ts filename="index.d.ts"
+export const enum Kind {
+  Duck = 'Duck',
+  Dog = 'Dog',
+  Cat = 'Cat',
+}
+```
+
+**NAPI-RS** não suporta a geração de `impl` de `enum` Rust em JavaScript.

--- a/pages/docs/concepts/exports.pt-BR.mdx
+++ b/pages/docs/concepts/exports.pt-BR.mdx
@@ -1,0 +1,66 @@
+# Exportações
+
+import { Callout } from 'nextra-theme-docs'
+
+<Callout type="info">
+Ao contrário da definição de módulos no Node.js, não precisamos registrar explicitamente as exportações como `module.exports.xxx = xxx`.
+
+O macro `#[napi]` irá gerar automaticamente o código de registro de módulo para você.
+Essa ideia de registro automático foi inspirada pelo [node-bindgen](https://github.com/infinyon/node-bindgen).
+
+</Callout>
+
+## `Function`
+
+Exportar uma função é incrivelmente simples. Basta decorar uma função rust normal com `#[napi]`:
+
+```rust filename="lib.rs"
+#[napi]
+fn sum(a: u32, b: u32) -> u32 {
+	a + b
+}
+```
+
+## `Const`
+
+```rust filename="lib.rs"
+#[napi]
+pub const DEFAULT_COST: u32 = 12;
+```
+
+```ts filename="index.d.ts"
+export const DEFAULT_COST: number
+```
+
+## `Class`
+
+Veja a [`seção class`](./class) para mais detalhes.
+
+```rust filename="lib.rs"
+#[napi(constructor)]
+struct Animal {
+  pub name: String,
+  pub kind: u32,
+}
+
+#[napi]
+impl Animal {
+  #[napi]
+  pub fn change_name(&mut self, new_name: String) {
+    self.name = new_name;
+  }
+}
+```
+
+## `Enum`
+
+Veja a [`seção enum`](./enum) para mais detalhes.
+
+```rust filename="lib.rs"
+#[napi]
+pub enum Kind {
+  Dog,
+  Cat,
+  Duck,
+}
+```

--- a/pages/docs/concepts/external.pt-BR.mdx
+++ b/pages/docs/concepts/external.pt-BR.mdx
@@ -1,0 +1,88 @@
+---
+description: External Object holds the native value in a JavaScript Object.
+---
+
+# External
+
+[`External`](https://nodejs.org/api/n-api.html#napi_create_external) é muito semelhante ao [`Object Wrap`](https://nodejs.org/api/n-api.html#object-wrap), que é usado em [Class](./class) por de baixo dos panos.
+
+`Object Wrap` anexa um valor nativo a um objeto JavaScript e pode notificá-lo quando o objeto JavaScript anexado é reciclado pelo GC. `External` cria um objeto JavaScript vazio que mantém o valor nativo nos bastidores. Ele só funciona passando o objeto de volta para Rust:
+
+```rust filename="lib.rs"
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+
+#[napi]
+fn create_source_map(length: u32) -> External<Buffer> {
+  External::new(vec![0; length as usize].into())
+}
+```
+
+⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️
+
+```ts filename="index.d.ts"
+export class ExternalObject<T> {
+  readonly '': {
+    readonly '': unique symbol
+    [K: symbol]: T
+  }
+}
+
+export function createSourceMap(length: number): ExternalObject<Buffer>
+```
+
+`External` é muito útil quando você deseja retornar um objeto JavaScript com alguns métodos nele para interagir com o código nativo Rust.
+Aqui está um exemplo do mundo real:
+
+https://github.com/h-a-n-a/magic-string-rs/blob/v0.3.0/node/src/lib.rs#L96-L103
+
+https://github.com/h-a-n-a/magic-string-rs/blob/v0.3.0/node/index.js#L7-L23
+
+```rust filename="lib.rs"
+impl MagicString {
+  #[napi(ts_return_type = "{ toString: () => string, toUrl: () => string }")]
+  pub fn generate_map(
+    &mut self,
+    options: Option<magic_string::GenerateDecodedMapOptions>,
+  ) -> Result<External<SourceMap>> {
+    let external = create_external(self.0.generate_map(options.unwrap_or_default())?);
+    Ok(external)
+  }
+
+  /// @internal
+  #[napi]
+  pub fn to_sourcemap_string(&mut self, sourcemap: External<SourceMap>) -> Result<String> {
+    Ok((*sourcemap.as_ref()).to_string()?)
+  }
+
+  /// @internal
+  #[napi]
+  pub fn to_sourcemap_url(&mut self, sourcemap: External<SourceMap>) -> Result<String> {
+    Ok((*sourcemap.as_ref()).to_url()?)
+  }
+}
+```
+
+Primeiro, o método `generate_map` retorna um objeto `External`, e então a função JavaScript mantém o objeto `External` no fechamento:
+
+```ts filename="index.js"
+module.exports.MagicString = class MagicString extends MagicStringNative {
+  generateMap(options) {
+    const sourcemap = super.generateMap({
+      file: null,
+      source: null,
+      sourceRoot: null,
+      includeContent: false,
+      ...options,
+    })
+
+    const toString = () => super.toSourcemapString(sourcemap)
+    const toUrl = () => super.toSourcemapUrl(sourcemap)
+
+    return {
+      toString,
+      toUrl,
+    }
+  }
+}
+```

--- a/pages/docs/concepts/function.pt-BR.md
+++ b/pages/docs/concepts/function.pt-BR.md
@@ -1,0 +1,78 @@
+---
+---
+
+# Function
+
+Definir uma `function` JavaScript é muito simples em **NAPI-RS**. Apenas uma simples Rust `fn`:
+
+```rust filename="lib.rs"
+#[napi]
+fn sum(a: u32, b: u32) -> u32 {
+  a + b
+}
+```
+
+A coisa mais importante que você deve ter em mente é que **_as fn em NAPI-RS não suportam todos os tipos de Rust_**. Aqui está uma tabela para ilustrar como os tipos JavaScript se mapeiam para os tipos de Rust quando são argumentos e tipos de retorno de uma `fn`:
+
+## Argumentos
+
+| Rust Type                                               | JavaScript Type                                                               |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `u32`                                                   | `number`                                                                      |
+| `i32`                                                   | `number`                                                                      |
+| `i64`                                                   | `number`                                                                      |
+| `f64`                                                   | `number`                                                                      |
+| `bool`                                                  | `boolean`                                                                     |
+| `String`                                                | `string`                                                                      |
+| `Latin1String`                                          | `string`                                                                      |
+| `UTF16String`                                           | `string`                                                                      |
+| `#[napi(object)] struct`                                | `Object`                                                                      |
+| `& struct` or `&mut struct`                             | [Class](./class) instance                                                     |
+| `serde_json::Map`                                       | `Object`                                                                      |
+| `serde_json::Value`                                     | `unknown`                                                                     |
+| `std::collections::HashMap`                             | `Object`                                                                      |
+| `Array`                                                 | `unknown[]`                                                                   |
+| `Vec<T>` T must be types in this table                  | T[]                                                                           |
+| `Buffer`                                                | `Buffer`                                                                      |
+| `External`                                              | [`External`](https://nodejs.org/api/n-api.html#napi_create_external)          |
+| `Null`                                                  | `null`                                                                        |
+| `Undefined` / `()`                                      | `undefined`                                                                   |
+| `Option<T>`                                             | `T or null`                                                                   |
+| `Fn(Arg) ->T` `Arg `and `T` must be types in this table | `(arg: Arg) => T`                                                             |
+| `Promise<T>`                                            | `Promise<T>`                                                                  |
+| `AbortSignal`                                           | [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) |
+| `JsSymbol`                                              | `Symbol`                                                                      |
+| `Int8Array` / `Uint8Array` / `Int16Array`...            | `TypedArray`                                                                  |
+| `BigInt`                                                | `BigInt`                                                                      |
+
+## Tipo de Retorno
+
+| Rust Type                                    | JavaScript Type  |
+| -------------------------------------------- | ---------------- |
+| `u32`                                        | `number`         |
+| `i32`                                        | `number`         |
+| `i64`                                        | `number`         |
+| `f64`                                        | `number`         |
+| `bool`                                       | `boolean`        |
+| `String`                                     | `string`         |
+| `Latin1String`                               | `string`         |
+| `UTF16String`                                | `string`         |
+| `#[napi(object)] struct`                     | `Object`         |
+| `#[napi] struct`                             | [Class](./class) |
+| `serde_json::Map`                            | `Object`         |
+| `serde_json::Value`                          | `unknown`        |
+| `std::collections::HashMap`                  | `Object`         |
+| `Array`                                      | `unknown[]`      |
+| `Vec<T>` T must be types in this table       | `T[]`            |
+| `Buffer`                                     | `Buffer`         |
+| `External`                                   | `External`       |
+| `Null`                                       | `null`           |
+| `Undefined` / `()`                           | `undefined`      |
+| `Option<T>`                                  | `T` or `null`    |
+| `AsyncTask<Task<JsValue = T>>`               | `Promise<T>`     |
+| `JsSymbol`                                   | `Symbol`         |
+| `Int8Array` / `Uint8Array` / `Int16Array`... | `TypedArray`     |
+| `BigInt`                                     | `BigInt`         |
+| `i64n`                                       | `BigInt`         |
+| `i128`                                       | `BigInt`         |
+| `u128`                                       | `BigInt`         |

--- a/pages/docs/concepts/inject-env.pt-BR.md
+++ b/pages/docs/concepts/inject-env.pt-BR.md
@@ -1,0 +1,57 @@
+---
+description: Inject Node-API Env into functions and methods.
+---
+
+# Inject Env
+
+O macro `#[napi]` é uma abstração de alto nível para o `Node-API`. Na maioria das vezes, você utiliza a API nativa do Rust e suas crates.
+
+Mas às vezes ainda é necessário acessar o `Node-API`, em um nível mais baixo, por exemplo, para chamar [`napi_async_cleanup_hook`](https://nodejs.org/api/n-api.html#napi_async_cleanup_hook) ou [`napi_adjust_external_memory`](https://nodejs.org/api/n-api.html#napi_adjust_external_memory).
+
+Para esse cenário, o **NAPI-RS** permite que você injete o `Env` em sua `fn` que está decorada com o `#[napi]`.
+
+```rust {4} filename="lib.rs"
+use napi::{Env, bindgen_prelude::*};
+
+#[napi]
+fn call_env(env: Env, length: u32) -> Result<External<Vec<u32>>> {
+  env.adjust_external_memory(length as i64)?;
+  Ok(External::new(vec![0; length as usize]))
+}
+```
+
+E o `Env` será injetado automaticamente pelo **NAPI-RS**, isso não afeta os tipos dos `arguments` do lado do JavaScript:
+
+```ts filename="index.d.ts"
+export function callEnv(length: number) -> ExternalObject<number[]>
+```
+
+Você também pode injetar `Env` no bloco `impl`:
+
+```rust {20} filename="lib.rs"
+use napi::bindgen_prelude::*;
+
+// Uma estrutura complexa que não pode ser exposta diretamente ao JavaScript.
+struct QueryEngine {}
+
+#[napi(js_name = "QueryEngine")]
+struct JsQueryEngine {
+  engine: QueryEngine,
+}
+
+#[napi]
+impl JsQueryEngine {
+  #[napi(factory)]
+  pub fn with_initial_count(count: u32) -> Self {
+    JsQueryEngine { engine: QueryEngine::with_initial_count(count) }
+  }
+
+  /// Método da classe
+  #[napi]
+  pub fn query(&self, env: Env, query: String) -> napi::Result<String> {
+    self.engine.query(query).map_err(|err| Error::new(Status::GenericFailure, format!("Query failed {}", err)))
+  }
+}
+```
+
+O comportamento é o mesmo que o de uma `fn` pura.

--- a/pages/docs/concepts/inject-this.pt-BR.md
+++ b/pages/docs/concepts/inject-this.pt-BR.md
@@ -1,0 +1,60 @@
+---
+description: Inject This Object into functions and methods.
+---
+
+# Inject This
+
+Nos métodos de classe, você pode querer acessar o valor bruto do `Object` da instância da `Class`.
+
+```rust {15} filename="lib.rs"
+use napi::{bindgen_prelude::*, JsObject};
+use napi_derive::napi;
+
+#[napi]
+pub struct QueryEngine {}
+
+#[napi]
+impl QueryEngine {
+  #[napi(constructor)]
+  pub fn new() -> Result<Self> {
+    Ok(Self {})
+  }
+
+  #[napi]
+  pub fn get_ref_count(&self, this: This<JsObject>) -> Result<Option<i32>> {
+    this.get::<i32>("refCount")
+  }
+}
+```
+
+```js {5} filename="main.mjs"
+import { QueryEngine } from './index.js'
+
+const qe = new QueryEngine()
+qe.refCount = 3
+console.log(qe.getRefCount()) // 3
+```
+
+Nas funções, elas podem ser vinculadas a alguns objetos em JavaScript:
+
+```rust {10} filename="lib.rs"
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+
+#[napi(constructor)]
+pub struct Width {
+  pub value: i32,
+}
+
+#[napi]
+pub fn plus_one(this: This<&Width>) -> i32 {
+  this.value + 1
+}
+```
+
+```js {4} filename="main.mjs"
+import { Width, plusOne } from './index.js'
+
+const width = new Width(1)
+console.log(plusOne.call(width)) // 2
+```

--- a/pages/docs/concepts/naming-conventions.pt-BR.md
+++ b/pages/docs/concepts/naming-conventions.pt-BR.md
@@ -1,0 +1,47 @@
+---
+title: 'Naming conventions'
+---
+
+# Convenções de nomenclatura
+
+## `snake_case` para `camelCase`
+
+Os estilos de código são muito diferentes entre Rust e JavaScript. A comunidade Rust prefere o estilo `snake_case`, enquanto a comunidade JavaScript prefere o estilo `camelCase`. **NAPI-RS** irá automaticamente alterar o estilo do código Rust para o estilo `camelCase`.
+
+```rust filename="lib.rs"
+#[napi]
+fn a_function(a_arg: u32) -> u32 {
+  a_arg + 1
+}
+```
+
+⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️
+
+```ts filename="index.d.ts"
+export function aFunction(aArg: number): number
+```
+
+## `js_name`
+
+Você pode usar o atributo `js_name` em `#[napi]` para renomear a função JavaScript.
+
+```rust {1} filename="lib.rs"
+#[napi(js_name = "coolFunction")]
+fn a_function(a_arg: u32) -> u32 {
+  a_arg + 1
+}
+```
+
+⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️
+
+```ts filename="index.d.ts"
+export function coolFunction(aArg: number): number
+```
+
+O nome da função JavaScript será `coolFunction`, tanto na definição TypeScript gerada quanto no tempo de execução JavaScript:
+
+```js {1} filename="test.mjs"
+import { coolFunction } from './index.js'
+
+console.log(coolFunction(1)) // 2
+```

--- a/pages/docs/concepts/object.pt-BR.mdx
+++ b/pages/docs/concepts/object.pt-BR.mdx
@@ -1,0 +1,55 @@
+---
+title: 'Object'
+---
+
+import { Callout } from 'nextra-theme-docs'
+
+# Object
+
+`Object` é muito fácil de confundir com o uso de `Class`. Ao contrário de `Class`, você não pode atribuir `function` ou `method` a um `Object`.
+
+```rust filename="lib.rs"
+#[napi(object)]
+pub struct Pet {
+  pub name: String,
+  pub kind: u32,
+}
+```
+
+Qualquer bloco `impl` desta `struct` não afetará o `Object` JavaScript.
+
+<Callout type="warning" emoji="⚠️">
+  Se você quiser converter uma `struct` Rust em um `Object` JavaScript usando o
+  atributo `#[napi(object)]`, você precisa marcar todos os seus campos como
+  `pub`.
+</Callout>
+
+Uma vez que a `struct` é marcada como `#[napi(object)]`, você pode usá-la como tipo de argumento de função ou tipo de retorno.
+
+```rust filename="lib.rs"
+#[napi(object)]
+pub struct Pet {
+  pub name: String,
+  pub kind: u32,
+}
+
+#[napi]
+fn print_pet(pet: Pet) {
+  println!("{}", pet.name);
+}
+
+#[napi]
+fn create_cat() -> Pet {
+  Pet {
+    name: "cat".to_string(),
+    kind: 1,
+  }
+}
+```
+
+<Callout type="warning" emoji="⚠️">
+  O objeto JavaScript passado para ou retornado de Rust é clonado. Isso
+  significa que qualquer mutação no `Object` do JavaScript não afetará a
+  `struct` Rust original. E qualquer mutação na `struct` Rust também não afetará
+  o `Object` JavaScript.
+</Callout>

--- a/pages/docs/concepts/reference.pt-BR.md
+++ b/pages/docs/concepts/reference.pt-BR.md
@@ -1,0 +1,195 @@
+---
+description: Create and use Object References.
+---
+
+# `Reference` / `WeakReference`
+
+## `Reference`
+
+Em alguns cenários, você pode querer manter uma referência a um `Object` criado em `Rust`. Por exemplo:
+
+```rust {11} filename="lib.rs"
+pub struct Repository {
+  dir: String,
+}
+
+impl Repository {
+  fn remote(&self) -> Remote {
+    Remote { inner: self }
+  }
+}
+
+pub struct Remote<'repo> {
+  inner: &'repo Repository,
+}
+
+impl<'repo> Remote<'repo> {
+  fn name(&self) -> String {
+    "origin".to_owned()
+  }
+}
+```
+
+A struct `Repository` abaixo é fácil de criar uma Classe `#[napi]` ao redor dela, porque não contém nenhum **lifetime** na definição.
+
+Mas a struct `Remote<'repo>` não poderia ser criada uma Classe `#[napi]` ao redor dela, porque existe o lifetime `'repo` nela.
+
+Com a API de `Reference` você pode criar uma struct com o lifetime `'static`, o que significa que a struct criada viverá enquanto você puder acessá-la em seu código `Rust`.
+
+Assim como o [`Env`](./inject-env) e o [`This`](./inject-this), o `Reference` é injetado nos parâmetros das funções `#[napi]`.
+
+```rust {37-42,45-48} filename="lib.rs"
+use napi::bindgen_prelude::*;
+
+pub struct Repository {
+  dir: String,
+}
+
+impl Repository {
+  fn remote(&self) -> Remote {
+    Remote { inner: self }
+  }
+}
+
+pub struct Remote<'repo> {
+  inner: &'repo Repository,
+}
+
+impl<'repo> Remote<'repo> {
+  fn name(&self) -> String {
+    "origin".to_owned()
+  }
+}
+
+#[napi]
+pub struct JsRepo {
+  inner: Repository,
+}
+
+#[napi]
+impl JsRepo {
+  #[napi(constructor)]
+  pub fn new(dir: String) -> Self {
+    JsRepo {
+      inner: Repository { dir },
+    }
+  }
+
+  #[napi]
+  pub fn remote(&self, reference: Reference<JsRepo>, env: Env) -> Result<JsRemote> {
+    Ok(JsRemote {
+      inner: reference.share_with(env, |repo| Ok(repo.inner.remote()))?,
+    })
+  }
+}
+
+#[napi]
+pub struct JsRemote {
+  inner: SharedReference<JsRepo, Remote<'static>>,
+}
+
+#[napi]
+impl JsRemote {
+  #[napi]
+  pub fn name(&self) -> String {
+    self.inner.name()
+  }
+}
+```
+
+Como você pode ver, o `Reference<JsRepo>` injetado possui a função `share_with` nele, que pode ser usada para criar uma estrutura `JsRepo` com tempo de vida `'static` no fechamento.
+
+![](/assets/reference.svg)
+
+O `Reference` criado fará com que o Node.js mantenha a instância `JsRepo` até que todas as referências sejam descartadas.
+
+## `WeakReference`
+
+`WeakReference` é muito útil quando você está criando referências circulares.
+
+```rust {13,24,71} filename="lib.rs"
+use std::{cell::RefCell, rc::Rc};
+
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+
+pub struct OwnedStyleSheet {
+  rules: Vec<String>,
+}
+
+#[napi]
+pub struct CSSRuleList {
+  owned: Rc<RefCell<OwnedStyleSheet>>,
+  parent: WeakReference<CSSStyleSheet>,
+}
+
+#[napi]
+impl CSSRuleList {
+  #[napi]
+  pub fn get_rules(&self) -> Vec<String> {
+    self.owned.borrow().rules.to_vec()
+  }
+
+  #[napi(getter)]
+  pub fn parent_style_sheet(&self) -> WeakReference<CSSStyleSheet> {
+    self.parent.clone()
+  }
+
+  #[napi(getter)]
+  pub fn name(&self, env: Env) -> Result<Option<String>> {
+    Ok(
+      self
+        .parent
+        .upgrade(env)?
+        .map(|stylesheet| stylesheet.name.clone()),
+    )
+  }
+}
+
+#[napi]
+pub struct CSSStyleSheet {
+  name: String,
+  inner: OwnedStyleSheet,
+  rules: Option<Reference<CSSRuleList>>,
+}
+
+#[napi]
+impl CSSStyleSheet {
+  #[napi(constructor)]
+  pub fn new(name: String, rules: Vec<String>) -> Result<Self> {
+    let inner = OwnedStyleSheet { rules };
+    Ok(CSSStyleSheet {
+      name,
+      inner,
+      rules: None,
+    })
+  }
+
+  #[napi(getter)]
+  pub fn rules(
+    &mut self,
+    env: Env,
+    reference: Reference<CSSStyleSheet>,
+  ) -> Result<Reference<CSSRuleList>> {
+    if let Some(rules) = &self.rules {
+      return rules.clone(env);
+    }
+
+    let rules = CSSRuleList::into_reference(
+      CSSRuleList {
+        owned: self.inner.clone(),
+        parent: reference.downgrade(),
+      },
+      env,
+    )?;
+
+    self.rules = Some(rules.clone(env)?);
+    Ok(rules)
+  }
+}
+```
+
+No exemplo acima, a struct `CSSRuleList` é criada com uma `WeakReference<CSSStyleSheet>` como seu campo `parent`.
+Como o `CSSRuleList` é criado pelo `CSSStyleSheet` neste caso, a instância `CSSStyleSheet` é uma referência circular para a instância `CSSRuleList` que criou.
+
+A `WeakReference` não aumentará a contagem de referência do objeto bruto, então o método `upgrade` de `WeakReference` pode retornar `None` se o objeto bruto for descartado.

--- a/pages/docs/concepts/threadsafe-function.pt-BR.mdx
+++ b/pages/docs/concepts/threadsafe-function.pt-BR.mdx
@@ -1,0 +1,160 @@
+---
+description: Call a JavaScript callback in other threads.
+---
+
+# ThreadsafeFunction
+
+[`ThreadSafe Function`](https://nodejs.org/api/n-api.html#asynchronous-thread-safe-function-calls) é um conceito complexo no Node.js. Como todos sabemos, o Node.js é single-threaded, então você não pode acessar [`napi_env`](https://nodejs.org/api/n-api.html#napi_env), [`napi_value`](https://nodejs.org/api/n-api.html#napi_value), e [`napi_ref`](https://nodejs.org/api/n-api.html#napi_ref) em outra thread.
+
+import { Callout } from 'nextra-theme-docs'
+
+<Callout>
+  [`napi_env`](https://nodejs.org/api/n-api.html#napi_env),
+  [`napi_value`](https://nodejs.org/api/n-api.html#napi_value), e
+  [`napi_ref`](https://nodejs.org/api/n-api.html#napi_ref) são conceitos de
+  baixo nível em `Node-API`, na qual a macro `#[napi]` do **NAPI-RS** é
+  construída em cima. **NAPI-RS** também fornece uma [API de baixo
+  nível](../compat-mode/concepts/env) para acessar a `Node-API` original.
+</Callout>
+
+`Node-API` fornece APIs complexas de `Threadsafe Function` para chamar funções JavaScript em outras threads. É muito complexo, então muitos desenvolvedores não entendem como usá-lo corretamente. O **NAPI-RS** fornece uma versão limitada das APIs de `Threadsafe Function` para facilitar o uso:
+
+```rust {10} filename="lib.rs"
+use std::thread;
+
+use napi::{
+  bindgen_prelude::*,
+  threadsafe_function::{ErrorStrategy, ThreadsafeFunction, ThreadsafeFunctionCallMode},
+};
+
+#[napi]
+pub fn call_threadsafe_function(callback: JsFunction) -> Result<()> {
+  let tsfn: ThreadsafeFunction<u32, ErrorStrategy::CalleeHandled> = callback
+    .create_threadsafe_function(0, |ctx| {
+      ctx.env.create_uint32(ctx.value + 1).map(|v| vec![v])
+    })?;
+  for n in 0..100 {
+    let tsfn = tsfn.clone();
+    thread::spawn(move || {
+      tsfn.call(Ok(n), ThreadsafeFunctionCallMode::Blocking);
+    });
+  }
+  Ok(())
+}
+```
+
+⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️
+
+```ts filename="index.d.ts"
+export function callThreadsafeFunction(callback: (...args: any[]) => any): void
+```
+
+`ThreadsafeFunction` é muito complexa, então o **NAPI-RS** não fornece a geração precisa de definição TypeScript para ela. Se você deseja ter um tipo TypeScript melhor, pode usar `#[napi(ts_args_type)]` para sobreescrever o tipo do argumento `JsFunction`:
+
+```rust {8} filename="lib.rs"
+use std::thread;
+
+use napi::{
+  bindgen_prelude::*,
+  threadsafe_function::{ErrorStrategy, ThreadsafeFunction, ThreadsafeFunctionCallMode},
+};
+
+#[napi(ts_args_type = "callback: (err: null | Error, result: number) => void")]
+pub fn call_threadsafe_function(callback: JsFunction) -> Result<()> {
+  let tsfn: ThreadsafeFunction<u32, ErrorStrategy::CalleeHandled> = callback
+    .create_threadsafe_function(0, |ctx| {
+      ctx.env.create_uint32(ctx.value + 1).map(|v| vec![v])
+    })?;
+  for n in 0..100 {
+    let tsfn = tsfn.clone();
+    thread::spawn(move || {
+      tsfn.call(Ok(n), ThreadsafeFunctionCallMode::Blocking);
+    });
+  }
+  Ok(())
+}
+```
+
+⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️
+
+```ts filename="index.d.ts"
+export function callThreadsafeFunction(
+  callback: (err: null | Error, result: number) => void,
+): void
+```
+
+## ErrorStrategy
+
+Existem duas estratégias diferentes de tratamento de erros para `Threadsafe Function`. A estratégia pode ser definida no segundo parâmetro genérico de `ThreadsafeFunction`:
+
+```rust filename="lib.rs"
+let tsfn: ThreadsafeFunction<u32, ErrorStrategy::CalleeHandled> = ...
+```
+
+O primeiro argumento no parâmetro genérico é o tipo de retorno da `Threadsafe Function`.
+
+### `ErrorStrategy::CalleeHandled`
+
+O `Err` do código Rust será passado como o primeiro argumento para a função de retorno de chamada(callback) JavaScript. Esse comportamento segue as convenções de retorno de chamada assíncrona do Node.js: https://nodejs.org/en/knowledge/errors/what-are-the-error-conventions/. Muitas APIs assíncronas no Node.js são projetadas nesse formato, como `fs.read`.
+
+Com `ErrorStrategy::CalleeHandled`, você deve chamar a `ThreadsafeFunction` com o tipo `Result`, para que o `Error` seja tratado e retornado para a função de callback JavaScript:
+
+```rust {10,17} filename="lib.rs"
+use std::thread;
+
+use napi::{
+  bindgen_prelude::*,
+  threadsafe_function::{ErrorStrategy, ThreadsafeFunction, ThreadsafeFunctionCallMode},
+};
+
+#[napi(ts_args_type = "callback: (err: null | Error, result: number) => void")]
+pub fn call_threadsafe_function(callback: JsFunction) -> Result<()> {
+  let tsfn: ThreadsafeFunction<u32, ErrorStrategy::CalleeHandled> = callback
+    .create_threadsafe_function(0, |ctx| {
+      ctx.env.create_uint32(ctx.value + 1).map(|v| vec![v])
+    })?;
+  for n in 0..100 {
+    let tsfn = tsfn.clone();
+    thread::spawn(move || {
+      tsfn.call(Ok(n), ThreadsafeFunctionCallMode::Blocking);
+    });
+  }
+  Ok(())
+}
+```
+
+### `ErrorStrategy::Fatal`
+
+Nenhum `Error` será retornado para o lado JavaScript. Você pode usar essa estratégia para evitar o encapsulamento `Ok` no lado Rust se seu código nunca retornar `Err`.
+
+Com essa estratégia, `ThreadsafeFunction` não precisa ser chamada com `Result<T>`, e o primeiro argumento do callback JavaScript é o valor vindo do Rust, não `Error | null`.
+
+```rust {10,17} filename="lib.rs"
+use std::thread;
+
+use napi::{
+  bindgen_prelude::*,
+  threadsafe_function::{ErrorStrategy, ThreadsafeFunction, ThreadsafeFunctionCallMode},
+};
+
+#[napi(ts_args_type = "callback: (result: number) => void")]
+pub fn call_threadsafe_function(callback: JsFunction) -> Result<()> {
+  let tsfn: ThreadsafeFunction<u32, ErrorStrategy::Fatal> = callback
+    .create_threadsafe_function(0, |ctx| {
+      ctx.env.create_uint32(ctx.value + 1).map(|v| vec![v])
+    })?;
+  for n in 0..100 {
+    let tsfn = tsfn.clone();
+    thread::spawn(move || {
+      tsfn.call(n, ThreadsafeFunctionCallMode::Blocking);
+    });
+  }
+  Ok(())
+}
+```
+
+⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️
+
+```ts {2} filename="index.d.ts"
+export function callThreadsafeFunction(callback: (result: number) => void): void
+```

--- a/pages/docs/concepts/typed-array.pt-BR.mdx
+++ b/pages/docs/concepts/typed-array.pt-BR.mdx
@@ -1,0 +1,30 @@
+---
+title: 'TypedArray'
+description: JavaScript TypedArray primitive.
+---
+
+import { Callout } from 'nextra-theme-docs'
+
+# TypedArray
+
+`TypedArray` descreve uma visualização semelhante a uma matriz de um [buffer de dados binários](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer). Usar `TypedArray` permite compartilhar dados entre Node.js e Rust sem copiar ou mover os dados subjacentes.
+
+## Buffer
+
+[`Buffer`](https://nodejs.org/api/buffer.html) é uma subclasse do [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) do JavaScript. É frequentemente usado para compartilhar dados entre Node.js e Rust.
+
+`Buffer` pode ser criado com `Vec<u8>`. Se você criar `Buffer` dessa forma, a propriedade do `Vec<8>` será transferida para o `v8`, e o `Vec<u8>` será descartado quando o `v8` coletar(GC) o `Buffer`.
+
+```rust {6} filename="lib.rs"
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+
+#[napi]
+pub fn create_buffer() -> Buffer {
+  vec![0, 1, 2].into()
+}
+```
+
+<Callout>
+  Abaixo o `Vec<u8>` subjacente não será movido ou copiado dessa maneira.
+</Callout>

--- a/pages/docs/concepts/types-overwrite.pt-BR.md
+++ b/pages/docs/concepts/types-overwrite.pt-BR.md
@@ -1,0 +1,99 @@
+---
+description: Overwrite the argument and return TypeScript types.
+---
+
+# Sobrescrita de Tipos
+
+Na maioria dos casos, o **NAPI-RS** irá gerar os tipos TypeScript corretos para você. Mas em alguns cenários, você pode querer sobrescrever o tipo dos argumentos ou o tipo de retorno.
+
+[ThreadsafeFunction](./threadsafe-function) é um exemplo disso, porque `ThreadsafeFunction` é muito complexo,
+o **NAPI-RS** não pode gerar os tipos TypeScript corretos para ele. Você sempre precisa sobrescrever o tipo de argumento.
+
+## `ts_args_type`
+
+Reescreva o tipo dos argumentos da função e o **NAPI-RS** colocará o tipo reescrito entre chaves na assinatura da função.
+
+```rust {1} filename="lib.rs"
+#[napi(ts_args_type="callback: (err: null | Error, result: number) => void")]
+fn call_threadsafe_function(callback: JsFunction) -> Result<()> {
+  let tsfn: ThreadsafeFunction<u32, ErrorStrategy::CalleeHandled> = callback
+    .create_threadsafe_function(0, |ctx| {
+      ctx.env.create_uint32(ctx.value + 1).map(|v| vec![v])
+    })?;
+  for n in 0..100 {
+    let tsfn = tsfn.clone();
+    thread::spawn(move || {
+      tsfn.call(Ok(n), ThreadsafeFunctionCallMode::Blocking);
+    });
+  }
+  Ok(())
+}
+```
+
+⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️
+
+```ts filename="index.d.ts"
+export function callThreadsafeFunction(
+  callback: (err: null | Error, result: number) => void,
+): void
+```
+
+## `ts_arg_type`
+
+Reescreva um ou mais tipos de argumentos de uma função _individualmente_, e o **NAPI-RS** colocará os tipos reescritos entre chaves na assinatura da função e irá derivar automaticamente os outros.
+
+```rust {1} filename="lib.rs"
+#[napi]
+fn override_individual_arg_on_function(
+  not_overridden: String,
+  #[napi(ts_arg_type = "() => string")] f: JsFunction,
+  not_overridden2: u32,
+) {
+// code ...
+}
+```
+
+```ts filename="index.d.ts"
+export function overrideIndividualArgOnFunction(
+  notOverridden: string,
+  f: () => string,
+  notOverridden2: number,
+): string
+```
+
+## `ts_return_type`
+
+Reescreva o tipo de retorno da função e o **NAPI-RS** adicionará o tipo reescrito ao final da assinatura da função.
+
+```rust {1} filename="lib.rs"
+#[napi(ts_return_type="number")]
+fn return_something_unknown(env: Env) -> Result<JsUnknown> {
+  env.create_uint32(42).map(|v| v.into_unknown())
+}
+```
+
+```ts filename="index.d.ts"
+export function returnSomethingUnknown(): number
+```
+
+## `ts_type`
+
+Sobrescreva o tipo gerado do TypeScript de um campo em uma struct.
+
+```rust {1} filename="lib.rs"
+#[napi(object)]
+pub struct TsTypeChanged {
+  #[napi(ts_type = "MySpecialString")]
+  pub type_override: String,
+
+  #[napi(ts_type = "object")]
+  pub type_override_optional: Option<String>,
+}
+```
+
+```ts filename="index.d.ts"
+export interface TsTypeChanged {
+  typeOverride: MySpecialString
+  typeOverrideOptional?: object
+}
+```

--- a/pages/docs/concepts/values.pt-BR.mdx
+++ b/pages/docs/concepts/values.pt-BR.mdx
@@ -1,0 +1,345 @@
+---
+title: 'Values'
+description: Conversions between Rust and JavaScript types.
+---
+
+# Valores
+
+Conversões entre tipos Rust e JavaScript.
+
+### Undefined
+
+Representa `undefined` no JavaScript.
+
+```rust {3} filename="lib.rs"
+#[napi]
+fn get_undefined() -> Undefined {
+	()
+}
+
+//  O retorno padrão ou a tupla vazia `()` são convertidos em `undefined` após serem convertidos em valor JavaScript.
+#[napi]
+fn log(n: u32) {
+	println!("{}", n);
+}
+```
+
+```ts filename="index.d.ts"
+export function getUndefined(): undefined
+export function log(n: number): void
+```
+
+### Null
+
+Representa o valor `null` em JavaScript.
+
+```rust {3} filename="lib.rs"
+#[napi]
+fn get_null() -> Null {
+	Null
+}
+
+#[napi]
+fn get_env(env: String) -> Option<String> {
+	match std::env::var(env) {
+		Ok(val) => Some(val),
+		Err(e) => None,
+	}
+}
+```
+
+```ts filename="index.d.ts"
+export function getNull(): null
+export function getEnv(env: string): string | null
+```
+
+### Numbers
+
+Tipo JavaScript `Number` com tipos Rust Int/Float: `u32`, `i32`, `i64`, `f64`.
+
+Para tipos Rust como `u64`, `u128`, `i128`, confira a seção [`BigInt`](#bigint).
+
+```rust filename="lib.rs"
+#[napi]
+fn sum(a: u32, b: i32) -> i64 {
+	(b + a as i32).into()
+}
+```
+
+```ts filename="index.d.ts"
+export function sum(a: number, b: number): number
+```
+
+### String
+
+Representa o tipo `String` do JavaScript.
+
+```rust {3} filename="lib.rs"
+#[napi]
+fn greet(name: String) -> String {
+	format!("greeting, {}", name)
+}
+```
+
+```ts filename="index.d.ts"
+export function greet(name: string): string
+```
+
+### Boolean
+
+Representa o tipo `Boolean` do JavaScript.
+
+```rust filename="lib.rs"
+#[napi]
+fn is_good() -> bool {
+	true
+}
+```
+
+```ts filename="index.d.ts"
+export function isGood(): boolean
+```
+
+### Buffer
+
+```rust filename="lib.rs"
+#[napi]
+fn with_buffer(buf: Buffer) {
+  let buf: Vec<u8> = buf.into();
+  // faz alguma coisa
+}
+
+#[napi]
+fn read_buffer(file: String) -> Buffer {
+	Buffer::from(std::fs::read(file).unwrap())
+}
+```
+
+```ts filename="index.d.ts"
+export function withBuffer(buf: Buffer): void
+export function readBuffer(file: string): Buffer
+```
+
+### Object
+
+Representa valores de objeto anônimo do JavaScript.
+
+import { Callout } from 'nextra-theme-docs'
+
+<Callout type="warning" emoji="⚠️">
+**Desempenho**
+
+Os custos de conversão de `Object` entre JavaScript e Rust são maiores do que outros tipos primitivos.
+
+Cada chamada de `Object.get("key")` é na verdade despachada para o lado do node, incluindo duas etapas: buscar valor, converter JS para valor de Rust, e o mesmo vale para `Object.set("key", v)`.
+
+</Callout>
+
+```rust filename="lib.rs"
+#[napi]
+fn keys(obj: Object) -> Vec<String> {
+	Object::keys(&obj).unwrap()
+}
+
+#[napi]
+fn log_string_field(obj: Object, field: String) {
+	println!("{}: {:?}", &field, obj.get::<String>::(field.as_ref()));
+}
+
+#[napi]
+fn create_obj(env: Env) -> Object {
+	let mut obj = env.create_object().unwrap();
+	obj.set("test", 1).unwrap();
+	obj
+}
+```
+
+```ts filename="index.d.ts"
+export function keys(obj: object): Array<string>
+export function logStringField(obj: object): void
+export function createObj(): object
+```
+
+Se você deseja que o **NAPI-RS** converta objetos do JavaScript com a mesma forma definida em Rust, você pode usar o macro `#[napi]` com o atributo `object`.
+
+```rust filename="lib.rs"
+/// #[napi(object)] requer que todos os campos da struct sejam públicos
+#[napi(object)]
+struct PackageJson {
+	pub name: String,
+	pub version: String,
+	pub dependencies: Option<HashMap<String, String>>,
+	pub dev_dependencies: Option<HashMap<String, String>>,
+}
+
+#[napi]
+fn log_package_name(package_json: PackageJson) {
+	println!("name: {}", package_json.name);
+}
+
+#[napi]
+fn read_package_json() -> PackageJson {
+	// ...
+}
+```
+
+```ts filename="index.d.ts"
+export interface PackageJson {
+  name: string
+  version: string
+  dependencies: Record<string, string> | null
+  devDependencies: Record<string, string> | null
+}
+export function logPackageName(packageJson: PackageJson): void
+export function readPackageJson(): PackageJson
+```
+
+<Callout type="warning" emoji="⚠️">
+**Clone sobre Referência**
+
+A estrutura `#[napi(object)]` passada na função Rust `fn` é clonada do **_JavaScript Object_**. Qualquer mutação nela não será refletida no objeto **_JavaScript_**.
+
+</Callout>
+
+```rust filename="lib.rs"
+/// #[napi(object)] requer que todos os campos da struct sejam públicos
+#[napi(object)]
+struct Animal {
+	pub name: String,
+}
+
+#[napi]
+fn change_animal_name(mut animal: Animal) {
+  animal.name = "cat".to_string();
+}
+```
+
+```js
+const animal = { name: 'dog' }
+changeAnimalName(animal)
+console.log(animal.name) // "dog"
+```
+
+### Array
+
+Porque os valores de `Array` em JavaScript podem conter elementos com tipos diferentes, mas `Vec<T>`
+em Rust só pode conter elementos do mesmo tipo. Portanto, existem duas maneiras diferentes para os tipos de array.
+
+<Callout type="warning" emoji="⚠️">
+**Desempenho**
+
+Como o tipo `Array` do JavaScript é realmente suportado por `Object`, o desempenho de manipulação de `Array`s seria o mesmo que o de `Object`s.
+
+A conversão entre `Array` e `Vec<T>` é ainda mais pesada, com complexidade `O(2n)`.
+
+</Callout>
+
+```rust filename="lib.rs"
+#[napi]
+fn arr_len(arr: Array) -> u32 {
+  arr.len()
+}
+
+#[napi]
+fn get_tuple_array(env: Env) -> Array {
+  let mut arr = env.create_array(2).unwrap();
+
+  arr.insert(1).unwrap();
+  arr.insert("test").unwrap();
+
+  arr
+}
+
+#[napi]
+fn vec_len(nums: Vec<u32>) -> u32 {
+  u32::try_from(nums.len()).unwrap()
+}
+
+#[napi]
+fn get_nums() -> Vec<u32> {
+  vec![1, 1, 2, 3, 5, 8]
+}
+```
+
+```ts filename="index.d.ts"
+export function arrLen(arr: unknown[]): number
+export function getTupleArray(): unknown[]
+export function vecLen(nums: Array<number>): number
+export function getNums(): Array<number>
+```
+
+### BigInt
+
+Isso requer o recurso `napi6`.
+
+<Callout type="warning" emoji="⚠️">
+  A única maneira de passar `BigInt` em `Rust` é usando o tipo `BigInt`. Mas
+  você pode retornar `BigInt`, `i64n`, `u64`, `i128`, `u128`. Retornar `i64`
+  será tratado como um número `JavaScript`, não `BigInt`.
+</Callout>
+
+<Callout>
+  A razão pela qual as funções Rust não podem receber `i128` `u128` `u64` `i64n`
+  como argumentos é que eles podem perder precisão ao converter `BigInt` do
+  JavaScript para eles. Você pode usar `BigInt::get_u128`, `BigInt::get_i128`
+  ... para obter o valor em `BigInt`. O valor de retorno desses métodos também
+  indica se houve perda de precisão.
+</Callout>
+
+```rust filename="lib.rs"
+/// O valor de retorno de `get_u128` é (signed: bool, value: u128, lossless: bool)
+#[napi]
+fn bigint_add(a: BigInt, b: BigInt) -> u128 {
+  a.get_u128().1 + b.get_u128().1
+}
+
+#[napi]
+fn create_big_int_i128() -> i128 {
+  100
+}
+```
+
+```ts filename="index.d.ts"
+export function bigintAdd(a: BigInt, b: BigInt): BigInt
+export function createBigIntI128(): BigInt
+```
+
+### TypedArray
+
+<Callout>
+  Ao contrário do objeto JavaScript, o `TypedArray` passado para a função Rust é
+  uma **Referência**. Nenhum dado `Copy` ou `Clone` será realizado. Toda mutação
+  no `TypedArray` será refletida no `TypedArray` JavaScript original.
+</Callout>
+
+```rust filename="lib.rs"
+#[napi]
+fn convert_u32_array(input: Uint32Array) -> Vec<u32> {
+  input.to_vec()
+}
+
+#[napi]
+fn create_external_typed_array() -> Uint32Array {
+  Uint32Array::new(vec![1, 2, 3, 4, 5])
+}
+
+#[napi]
+fn mutate_typed_array(mut input: Float32Array) {
+  for item in input.as_mut() {
+    *item *= 2.0;
+  }
+}
+```
+
+```ts filename="index.d.ts"
+export function convertU32Array(input: Uint32Array): Array<number>
+export function createExternalTypedArray(): Uint32Array
+export function mutateTypedArray(input: Float32Array): void
+```
+
+```js filename="test.mjs"
+import { convertU32Array, mutateTypedArray } from './index.js'
+
+convertU32Array(new Uint32Array([1, 2, 3, 4, 5])) // [1, 2, 3, 4, 5]
+mutateTypedArray(new Float32Array([1, 2, 3, 4, 5])) // Float32Array(5) [ 2, 4, 6, 8, 10 ]
+```

--- a/pages/docs/cross-build/_meta.pt-BR.json
+++ b/pages/docs/cross-build/_meta.pt-BR.json
@@ -1,0 +1,3 @@
+{
+  "summary": "Resumo"
+}

--- a/pages/docs/cross-build/summary.pt-BR.mdx
+++ b/pages/docs/cross-build/summary.pt-BR.mdx
@@ -1,0 +1,45 @@
+---
+description: Summary of cross build NAPI-RS packages.
+---
+
+# Sumário da compilação cruzada de pacotes NAPI-RS
+
+O NAPI-RS tem como objetivo fornecer uma solução completa para a construção de complementos nativos do Node.js, especialmente para usuários empresariais.
+
+Para os projetos de código aberto no GitHub, o **NAPI-RS** forneceu suporte integrado para CI/CD para construção e publicação de binários pré-compilados para Windows, Linux, macOS e FreeBSD com o lançamento do **NAPI-RS** v2. Também existem muitos usuários que estão usando CI auto-hospedado e desejam construir complementos nativos para várias plataformas em um único sistema (principalmente Linux). O **NAPI-RS** v2 fornece uma solução para esse caso de uso.
+
+Há um [projeto de demonstração](https://github.com/napi-rs/cross-build) para aqueles usuários que desejam construir complementos multiplataforma em um único sistema. A CI deste projeto constrói pacotes **NAPI-RS** em um CI Linux do GitHub e produz complementos para as seguintes plataformas:
+
+- Windows x64
+- Windows x86
+- Windows arm64
+- macOS x64
+- macOS arm64
+- Linux x64 gnu (`glibc` 2.17)
+- Linux x64 musl
+- Linux arm64 gnu (`glibc` 2.17)
+- Linux arm64 musl
+- Linux armv7 gnueabihf
+- Android arm64
+- Android armv7
+
+Se você estiver construindo pacotes NAPI-RS com um CI Linux auto-hospedado, você deve instalar o seguinte conjunto de ferramentas para construir os complementos para as plataformas acima:
+
+- Conjunto de ferramentas `Rust`, incluindo `Cargo`, `rustup` e sua std de destino Rust. ex: `rustup target add aarch64-apple-darwin`.
+- [`llvm`](https://apt.llvm.org/). A versão mais recente _qualificada_ é recomendada.
+- [`cargo-xwin`](https://github.com/messense/cargo-xwin) se você quiser construir para o Windows em um sistema não Windows. `cargo install cargo-xwin`.
+
+## Suporte da plataforma de hospedagem
+
+- Linux x64/arm64 tanto gnu quanto musl ✅
+- macOS x64/arm64 ✅
+- O Windows está bloqueado por: https://github.com/ziglang/zig/issues/10881
+
+## Patrocine nossa equipe
+
+https://github.com/sponsors/napi-rs/
+
+Integrar e configurar adequadamente uma cadeia de ferramentas de compilação multiplataforma na comunidade de código aberto pode ser muito tedioso e trabalhoso. Compreender esses parâmetros de compilação e resolver possíveis bugs pode ser muito demorado e difícil de testar.
+Um agradecimento especial para nosso membro da equipe [@messense](https://github.com/messense) que tem trabalhado no `cargo-xwin`, que nos permite construir complementos nativos do Windows em sistemas não Windows.
+
+Se você está usando NAPI-RS em sua empresa, considere patrocinar nossa equipe para apoiar o desenvolvimento do NAPI-RS. Ficaremos muito gratos pelo seu apoio.

--- a/pages/docs/deep-dive/_meta.pt-BR.json
+++ b/pages/docs/deep-dive/_meta.pt-BR.json
@@ -1,0 +1,5 @@
+{
+  "native-module": "Módulo nativo",
+  "history": "História",
+  "release": "Publicar pacotes nativos"
+}

--- a/pages/docs/deep-dive/_meta.pt-BR.json
+++ b/pages/docs/deep-dive/_meta.pt-BR.json
@@ -1,5 +1,5 @@
 {
   "native-module": "Módulo nativo",
   "history": "História",
-  "release": "Publicar pacotes nativos"
+  "release": "Release de pacotes nativos"
 }

--- a/pages/docs/deep-dive/history.pt-BR.mdx
+++ b/pages/docs/deep-dive/history.pt-BR.mdx
@@ -1,0 +1,252 @@
+---
+description: The history of writing Node.js native addons.
+---
+
+# História
+
+> Algumas partes foram retiradas de https://xcoder.in/2017/07/01/nodejs-addon-history/
+
+## A era feudal: Usando cabeçalhos `v8 C++` diretamente
+
+Nos primórdios, os desenvolvedores estavam usando os cabeçalhos `v8/Node C++` diretamente para construir _Node.js native addon_.
+
+```cpp
+Handle<Value> Echo(const Arguments& args)
+{
+    HandleScope scope;
+
+    if(args.Length() < 1)
+    {
+        ThrowException(
+            Exception::TypeError(
+                String::New("Wrong number of arguments.")));
+        return scope.Close(Undefined());
+    }
+
+    return scope.Close(args[0]);
+}
+
+void Init(Handle<Object> exports)
+{
+    exports->Set(String::NewSymbol("echo"),
+        FunctionTemplate::New(Echo)->GetFunction());
+}
+```
+
+Este trecho de código define uma função simples do Node.js: `echo`. Ela sempre retorna o primeiro argumento passado. E é equivalente a este código simples do `Node.js`:
+
+```js
+exports.echo = function () {
+  if (arguments.length < 1) throw new Error('Wrong number of arguments.')
+  return arguments[0]
+}
+```
+
+Se você publicar esses códigos como um pacote `npm`, ele só funcionará com `node 0.10.x`.
+
+Mas por quê? A resposta curta é **_o v8 e as APIs do Node.js mudam rapidamente._** Por exemplo, no `Node.js 6.x`, a forma de definir `JsFunction` mudou:
+
+```cpp
+Handle<Value> Echo(const Arguments& args);    // 0.10.x
+void Echo(FunctionCallbackInfo<Value>& args); // 6.x
+```
+
+Então, pacotes nativos desenvolvidos dessa maneira só podem suportar algumas versões do Node.js, quando a API do `v8` ou do `Node.js` muda, esses pacotes não podem mais ser compilados. E se os mantenedores atualizarem a API para o Node.js e `v8` mais recentes, o pacote não poderá ser compilado em versões mais antigas do Node.js novamente.
+
+## A era do Castelo: Abstrações nativas para o Node.js
+
+De volta a 2013, com a rápida iteração do `Node.js` e do `v8`, os pacotes que usavam a maneira antiga de construir complementos nativos cresciam com dores. E [`NAN`](https://github.com/nodejs/nan) surgiu. É uma abreviação para **Native Abstractions for Node.js**.
+
+> O NAN foi construído por [Rod Vagg](https://github.com/rvagg) e depois por [Benjamin Byholm](https://github.com/kkoopa). O NAN pertencia à conta do GitHub de Rod Vaggs desde o início e foi transferido para a organização `io.js` na era sombria da divisão do `Node.js` em `io.js` e `Node.js`; depois que eles se reuniram, o NAN finalmente foi transferido para a organização `Node.js`.
+
+Depois que o NAN surgiu, a experiência de desenvolvimento em pacotes de complementos nativos entrou na **_era do Castelo_**, e permanece até os dias atuais.
+
+A descrição completa do NAN ainda é um pouco abstrata: **_Abstrações nativas para o Node.js_**. Para ser mais específico, é um conjunto de **_macros em C_**. Você pode definir uma função JavaScript assim, por exemplo:
+
+```cpp
+NAN_METHOD(Echo)
+{
+}
+```
+
+A macro do NAN será expandida para diferentes códigos CPP durante a compilação de acordo com a versão do Node.js:
+
+```cpp
+Handle<Value> Echo(const Arguments& args);    // 0.10.x
+void Echo(FunctionCallbackInfo<Value>& args); // 6.x
+```
+
+`NAN_METHOD` será expandido pelo NAN para os trechos de código abaixo.
+
+Existem toneladas de macros no NAN além de `NAN_METHOD`, os desenvolvedores podem usá-lo para fazer quase qualquer coisa.
+
+Por exemplo, o `Nan::HandleScope` permite declarar um **escopo de alça**, `Nan::AsyncWorker` permite iniciar uma tarefa no `libuv`.
+
+Então, na **era do Castelo**, aqui está como se parece o addon nativo em c++:
+
+```cpp
+NAN_METHOD(Echo)
+{
+    if(info.Length() < 1)
+    {
+        Nan::ThrowError("Wrong number of arguments.");
+        return info.GetReturnValue().Set(Nan::Undefined());
+    }
+
+    info.GetReturnValue().Set(info[0]);
+}
+
+NAN_MODULE_INIT(InitAll)
+{
+    Nan::Set(
+        target,
+        Nan::New<String>("echo").ToLocalChecked(),
+        Nan::GetFunction(Nan::New<v8::FunctionTemplate>(Echo)).ToLocalChecked());
+}
+```
+
+O benefício de escrever códigos dessa forma é que os códigos podem ser atualizados automaticamente com a atualização do NAN, tornando-os compatíveis com todas as versões do Node.js.
+
+> Mesmo uma coisa boa como o NAN tem uma missão, e qualquer coisa fora dessa missão será gradualmente eliminada. Versões como 0.10.x e 0.12.x, por exemplo, devem ser aposentadas, e o NAN irá gradualmente abandonar a compatibilidade e o suporte para elas.
+
+## Era dos Impérios: ABI-compliant N-API
+
+Desde o lançamento do Node.js v8.0.0, o Node.js introduziu uma nova interface para desenvolvimento de módulos nativos C++, a **N-API**.
+
+> De acordo com a documentação oficial, é pronunciado com um único N, mais API, o que significa que as quatro letras em inglês são pronunciadas separadamente.
+
+Como isso difere das três eras anteriores? Por que seria uma era ainda maior de impérios?
+
+Em primeiro lugar, sabemos que mesmo sob o desenvolvimento do NAN, o código escrito uma vez precisa ser recompilado sob diferentes versões do Node.js, caso contrário, o Node.js não carregará uma extensão C++ corretamente se as versões não corresponderem. Em outras palavras, escreva uma vez, compile em qualquer lugar.
+
+A N-API, em comparação com o NAN, encapsula todas as estruturas de dados subjacentes do Node.js e as abstrai na interface da N-API.
+
+Diferentes versões do Node.js usam a mesma interface, que é estavelmente compatível com ABI, ou seja, a Interface Binária de Aplicativo (ABI). Isso permite que as extensões C++ compiladas sejam usadas diretamente sem recompilação, desde que o número da versão do ABI seja o mesmo em todas as versões do Node.js. Na verdade, o Node.js que suporta a interface N-API especifica a versão atual do ABI usada pelo Node.js.
+
+Para alcançar o objetivo oculto acima, a postura de usar a N-API parece com isso:
+
+- Forneça o arquivo de cabeçalho `node_api.h`.
+- Qualquer chamada de N-API retorna um `enum napi_status` para indicar se a chamada foi bem-sucedida ou não.
+- O valor de retorno da N-API é ocupado por `napi_status`, então o valor de retorno real é herdado dos argumentos de entrada.
+- Todos os tipos de dados JavaScript são envolvidos no tipo de caixa preta `napi_value`, não mais tipos como `v8::Object`, `v8::Number`, e assim por diante.
+- Se a chamada de função não for bem-sucedida, a função `napi_get_last_error_info` pode ser usada para obter informações sobre o último erro.
+
+Para obter mais detalhes sobre as funções da N-API, visite sua [documentação](https://nodejs.org/api/n-api.html), mas por enquanto, vamos dar uma olhada em algo um pouco menos abstrato para lhe dar uma ideia da N-API.
+
+### Inicialização do Módulo
+
+Nas eras **_Feudal_** e NAN, a inicialização do módulo era deixada para os macros fornecidos pelo Node.js.
+
+```cpp
+NODE_MODULE(addon, Init)
+```
+
+Na N-API atual, isso se torna um macro da N-API.
+
+```cpp
+NODE_MODULE(addon, Init)
+```
+
+Consequentemente, esta função de inicialização `Init` será escrita de forma diferente. Por exemplo, ela é escrita de duas maneiras diferentes na era feudal e na era do NAN:
+
+```cpp
+// Feudal style
+void Init(Local<Object> exports) {
+    NODE_SET_METHOD(exports, "echo", Echo);
+}
+
+// NAN style
+NAN_MODULE_INIT(Init)
+{
+    Nan::Set(
+        target,
+        Nan::New<String>("echo").ToLocalChecked(),
+        Nan::GetFunction(Nan::New<v8::FunctionTemplate>(Echo)).ToLocalChecked());
+}
+```
+
+A função `Init` deve se parecer com isso quando se trata de N-API:
+
+```cpp
+void Init(napi_env env, napi_value exports, napi_value module, void* priv)
+{
+    napi_status status;
+
+    // Description constructs for setting exports
+    napi_property_descriptor desc =
+        { "echo", 0, Echo, 0, 0, 0, napi_default, 0 };
+
+    // set "echo" into `module.exports`
+    status = napi_define_properties(env, exports, 1, &desc);
+}
+```
+
+<blockquote>
+
+`napi_property_descriptor` é uma estrutura de descrição para configurar propriedades de objeto, que é declarada da seguinte forma:
+
+```cpp
+typedef struct {
+  const char* utf8name;
+  napi_value name;
+
+  napi_callback method;
+  napi_callback getter;
+  napi_callback setter;
+  napi_value value;
+
+  napi_property_attributes attributes;
+  void* data;
+} napi_property_descriptor;
+```
+
+> Então, o `desc` na função `Init` acima significa que algo chamado "echo" é definido sob o objeto a ser instalado, a função é `Echo`, todos os outros `getters`, `setters`, e assim por diante são ponteiros vazios, e a propriedade é `napi_default`.
+
+</blockquote>
+
+### Declarar Funções
+
+Lembra-se das duas declarações de função anteriores? Vamos para a terceira vez:
+
+```cpp
+Handle<Value> Echo(const Arguments& args);    // 0.10.x
+void Echo(FunctionCallbackInfo<Value>& args); // 6.x
+```
+
+No N-API, você não precisa mais ter um histórico em `C++`, `C` é suficiente. Pois em N-API, declarar um Echo se parece com isso:
+
+```c
+napi_value Echo(napi_env env, napi_callback_info info)
+{
+    napi_status status;
+
+    size_t argc = 1;
+    napi_value argv[1];
+    status = napi_get_cb_info(env, info, &argc, argv, 0, 0);
+    if(status != napi_ok || argc < 1)
+    {
+        napi_throw_type_error(env, "Wrong number of arguments");
+        return 0; // `napi_value` is actually a pointer, returning a null pointer means no return value.
+    }
+
+    return argv[0];
+}
+
+```
+
+Análise passo a passo do código acima:
+
+- `napi_get_cb_info` Obtém informações sobre os parâmetros da solicitação de função atual, incluindo o número de parâmetros e seus corpos (que são representados como uma matriz de napi_value).
+- Verifica se há um erro na chamada (status não é igual a napi_ok) ou se o número de parâmetros é menor que 1.
+  - Se houver um erro na chamada ou o número de argumentos for menor que 1, um objeto de erro é lançado no nível do JavaScript via `napi_throw_type_error` e retornado.
+  - Prossegue se não houver erros.
+- Retorna `argv[0]`, o primeiro argumento
+
+## Conclusão
+
+Esta sessão explica a mudança na abordagem para o desenvolvimento de módulos C++ nativos no Node.js:
+
+- De node-waf para node-gyp, é uma mudança nas ferramentas de compilação, talvez GN ou algo mais no futuro.
+- De quebra de código para o surgimento do NAN, a comunidade Node.js viu sua parcela justa de amores e ódios, até o novo integrante, N-API, que trouxe sangue novo para o desenvolvimento de módulos C++ nativos.
+
+Espero que isso ajude você a entender a história azeda do desenvolvimento de módulos nativos do Node.js e os motivos e o contexto para o surgimento do N-API.

--- a/pages/docs/deep-dive/native-module.pt-BR.mdx
+++ b/pages/docs/deep-dive/native-module.pt-BR.mdx
@@ -1,0 +1,187 @@
+---
+description: What is native module, how Node.js load and execute it.
+---
+
+# Módulo nativo
+
+> Alguns conteúdos foram retirados de https://xcoder.in/2017/07/01/nodejs-addon-history/
+
+## A Natureza dos Módulos Nativos
+
+Vamos começar com o desenvolvimento do módulo C++ mais essencial para o Node.js. Por exemplo, temos um módulo nativo legítimo chamado `pinyin.linux-x64-gnu.node` no Linux, que é na verdade um arquivo binário que não pode ser visualizado corretamente em um editor de texto, até encontrarmos um visualizador de binário.
+
+![](./hex.png)
+
+O leitor perspicaz verá que seu Número Mágico[^1] é `0x7F454C46` e o código ASCII que ele pressiona é ELF, então a resposta é óbvia: é um arquivo **_DLL_** para Linux.
+
+Na verdade, não apenas no Linux. Quando um módulo C++ do Node.js é compilado no OSX, você obtém uma DLL com o sufixo `*.node`, que essencialmente é `*.dylib`, e no Windows, você obtém uma DLL com o sufixo `*.node`, que essencialmente é `*.dll`.
+
+SEsse tipo de módulo, quando requerido no Node.js, é exigido por meio de `process.dlopen()`. Vamos dar uma olhada na função DLOpen[^2] no Node.js [v10.23.0](https://github.com/nodejs/node/blob/v10.23.0/src/node.cc#L1232):
+
+```cpp
+// DLOpen is process.dlopen(module, filename, flags).
+void DLOpen(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  auto context = env->context();
+
+  Local<Object> module;
+  Local<Object> exports;
+  Local<Value> exports_v;
+  // initialize `module`, `module.exports` values
+  if (!args[0]->ToObject(context).ToLocal(&module) ||
+      // this line is equal to `exports = module.exports`
+      !module->Get(context, env->exports_string()).ToLocal(&exports_v) ||
+      !exports_v->ToObject(context).ToLocal(&exports)) {
+    return;  // Exception pending.
+  }
+
+  node::Utf8Value filename(env->isolate(), args[1]);  // Cast
+  DLib dlib(*filename, flags);
+  bool is_opened = dlib.Open();
+
+  node_module* const mp = static_cast<node_module*>(
+      uv_key_get(&thread_local_modpending));
+  uv_key_set(&thread_local_modpending, nullptr);
+
+  ...
+
+  // transfer the handle in dynamic lib to the `mp`
+  mp->nm_dso_handle = dlib.handle_;
+  mp->nm_link = modlist_addon;
+  modlist_addon = mp;
+
+  if (mp->nm_context_register_func != nullptr) {
+    mp->nm_context_register_func(exports, module, context, mp->nm_priv);
+  } else if (mp->nm_register_func != nullptr) {
+    mp->nm_register_func(exports, module, mp->nm_priv);
+  } else {
+    dlib.Close();
+    env->ThrowError("Module has no declared entry point.");
+    return;
+  }
+
+}
+```
+
+Logicamente, o processo de carregamento realmente se parece com isso.
+
+- Carrega a biblioteca de link via `uv_dlopen`.
+- Hook da biblioteca carregada na tabela de cadeia de módulos nativos.
+- Inicializa o módulo com `mp->nm_register_func()`, e obtém o módulo e module.exports que estão lá.
+
+O fluxo descendente é semelhante a este diagrama de fluxo:
+
+![nm flow](./nm-flow.png)
+
+## Como construir um módulo nativo
+
+### `node-waf`
+
+Antes do Node.js 0.8, os desenvolvedores usavam o `node-waf` para construir suas bibliotecas. Claro, o `node-waf` não é o node-waf no registro npm, o `node-waf` original estava abandonado há anos.
+
+Isso era configurado com um arquivo chamado `wscript`. A partir do Node.js 0.8, ele tinha o `node-gyp` integrado, então as pessoas não precisavam mais do wscript.
+
+Mas devido a essa escassez temporária, muitas bibliotecas que usam C++ para construir um addon do Node.js continham tanto `binding.gyp` quanto `wscript` naquela época.
+
+Você pode ver arquivos daquela época nesta biblioteca [node-mysql-libmysqlclient](https://github.com/Sannis/node-mysql-libmysqlclient/tree/9545ea7485fcc8b07b7c56c5ec3575938bfd4e5f). Para ter suporte ao node-gyp, ele tinha `binding.gyp` e ainda mantinha o arquivo `wscript`.
+
+### `node-gyp`
+
+Este recurso está presente no Node.js desde o Node.js v0.8, antes disso, seu pacote padrão de ajuda para compilação era o `node-waf` (veja abaixo), o que deve ser familiar para os antigos usuários do Node.
+
+### `GYP`
+
+`node-gyp` é baseado em `GYP`[^3]. Ele reconhece o arquivo `binding.gyp`[^4] em um pacote ou projeto e, em seguida, gera projetos compiláveis para cada sistema com base nesse arquivo de configuração, como **arquivos de projeto do Visual Studio (\*.sln, etc.)** para Windows e Makefiles para Unix. `node-gyp` também pode invocar ferramentas de compilação do sistema (como o GCC) para compilar o projeto para um arquivo final de DLL \*.node.
+
+> Como você pode ver pela descrição acima, compilar módulos nativos C++ no Windows depende do Visual Studio, razão pela qual você precisará ter o Visual Studio pré-instalado para instalar alguns pacotes do Node.js. <br/>
+> Na verdade, para usuários que não precisam do Visual Studio, não é necessário, já que o node-gyp só depende de seu compilador, não do IDE. Aqueles que desejam simplificar a instalação podem visitar [https://download.microsoft.com/download/5/f/7/5f7acaeb-8363-451f-9425-68a90f98b238/visualcppbuildtools_full.exe](https://download.microsoft.com/download/5/f/7/5f7acaeb-8363-451f-9425-68a90f98b238/visualcppbuildtools_full.exe) diretamente. cpp-build-tools Baixe a instalação das Ferramentas de Compilação do Visual CPP ou instale-as a partir da linha de comando `npm install --global --production windows-build-tools` para obter as ferramentas de compilação que você merece.
+
+Agora que isso está claro, vamos dar uma olhada na estrutura básica do `binding.gyp`:
+
+```text filename="binding.gyp"
+{
+  "targets": [{
+    "target_name": "addon1",
+    "sources": [ "1/addon.cc", "1/myobject.cc" ]
+  }, {
+    "target_name": "addon2",
+    "sources": [ "2/addon.cc", "2/myobject.cc" ]
+  }, {
+    "target_name": "addon3",
+    "sources": [ "3/addon.cc", "3/myobject.cc" ]
+  }, {
+    "target_name": "addon4",
+    "sources": [ "4/addon.cc", "4/myobject.cc" ]
+  }]
+}
+```
+
+Esta configuração conta a seguinte história:
+
+- Quatro módulos nativos em C++ são definidos.
+- O código-fonte para cada módulo é **\*.addon.cc** e **\*.myobject.cc**, respectivamente.
+- Os nomes dos quatro módulos são **addon1** a **addon4**.
+- A história oculta: Esses módulos existem em **build/Release/addon\*.node** após a compilação.
+
+Para obter mais informações sobre o arquivo de configuração GYP, você pode consultar a documentação oficial, que tem um link para GYP em uma nota de rodapé.
+
+#### Algo mais sobre `node-gyp`
+
+Além de ser baseado em GYP, o node-gyp faz algumas coisas extras. Em primeiro lugar, quando compilamos uma extensão nativa em C++, ele vai para o diretório especificado (geralmente `~/.node-gyp`) e procura pelas cabeçalhos da versão atual do Node.js e bibliotecas vinculadas estaticamente, e se elas não existirem, ele fervorosamente vai para o site do Node.js para baixá-las.
+
+Esta é uma estrutura de diretórios para a versão específica de cabeçalhos e bibliotecas do Node.js baixadas do node-gyp no macOS:
+
+```text
+/Users/napi-rs/.node-gyp
+└── 14.15.1
+    └── include
+        └── node
+            ├── common.gypi
+            ├── config.gypi
+            ├── cppgc
+            ├── js_native_api.h
+            ├── js_native_api_types.h
+            ├── libplatform
+            ├── node.h
+            ├── node_api.h
+            ├── node_api_types.h
+            ├── node_buffer.h
+            ├── node_object_wrap.h
+            ├── node_version.h
+            ├── openssl
+            ├── uv
+            ├── uv.h
+            ├── v8-fast-api-calls.h
+            ├── v8-internal.h
+            ├── v8-platform.h
+            ├── v8-profiler.h
+            ├── v8-util.h
+            ├── v8-value-serializer-version.h
+            ├── v8-version-string.h
+            ├── v8-version.h
+            ├── v8-wasm-trap-handler-posix.h
+            ├── v8-wasm-trap-handler-win.h
+            ├── v8.h
+            └── v8config.h
+```
+
+Este diretório de cabeçalhos será mesclado em nosso `binding.gyp` na forma de um campo `"include_dirs"` quando o `node-gyp` for compilado; em resumo, todos os cabeçalhos podem ser `#include` diretamente.
+
+O node-gyp é um programa de linha de comando que pode ser executado diretamente a partir de `$ node-gyp` após a instalação. Ele tem alguns subcomandos para você usar.
+
+- `$ node-gyp configure`: gera arquivos de projeto, como Makefiles, a partir do binding.gyp no diretório atual.
+- `$ node-gyp build`: constrói e compila o projeto atual, que deve ser precedido por `configure`.
+- `$ node-gyp clean`: limpa os arquivos de construção resultantes e os diretórios de saída, em outras palavras, limpa os diretórios.
+- `$ node-gyp rebuild`: Isso é equivalente à execução de `clean`, `configure` e `build` em sequência.
+- `$ node-gyp install`: Baixa manualmente os arquivos de cabeçalho e os arquivos de biblioteca da versão atual do Node.js para o diretório apropriado.
+
+## Conclusão
+
+Neste capítulo, introduzimos o que é um _Node.js native addon_ e como compilá-lo. No próximo capítulo, revisaremos a história das alterações na API relacionadas ao _native addon_ no Node.js e formalmente apresentaremos nosso protagonista: o N-API.
+
+## Referências
+
+[^1]: https://en.wikipedia.org/wiki/Magic_number_(programming)
+[^2]: https://github.com/nodejs/node/blob/v6.9.4/src/node.cc#L2427-L2502
+[^3]: GYP significa _Generate Your Projects_, um sistema de compilação desenvolvido pelo Google. Para mais detalhes: https://gyp.gsrc.io.
+[^4]: O arquivo de configuração do GYP geralmente tem uma extensão _.gyp, ou _.gypi. É um arquivo JSON-like.

--- a/pages/docs/deep-dive/release.pt-BR.mdx
+++ b/pages/docs/deep-dive/release.pt-BR.mdx
@@ -1,0 +1,94 @@
+---
+description: The history of how to release native packages.
+---
+
+# Release de Pacotes Nativos
+
+Como você pode ver na seção anterior, o método de distribuição dominante na comunidade é **_distribuir o código-fonte `C/C++` diretamente_**.
+No entanto, essa abordagem não é uma solução de distribuição aceitável para desenvolvedores que usam `Rust` para escrever complementos nativos do Node.js,
+devido à complexidade e tempo de compilação da cadeia de ferramentas do Rust, tornando a distribuição do código-fonte diretamente um grande problema para os desenvolvedores que usam esses complementos nativos.
+
+A seguir, descreverei várias maneiras de distribuir complementos nativos, incluindo **_distribuição direta do código-fonte_**. Após esta introdução, acredito que você poderá encontrar a forma mais adequada de distribuição de complementos nativos para `Rust`.
+
+## 1. Distribuição do Código-fonte
+
+Usar esse método requer que o usuário instale ferramentas de compilação como `node-gyp`, `cmake`, `g++`, etc.
+Isso não é um problema durante a fase de desenvolvimento, mas com a popularidade do `Docker`,
+instalar um monte de ferramentas de compilação em um determinado ambiente `Docker` é um pesadelo para muitas equipes.
+E se esse problema não for tratado adequadamente, aumentará o tamanho da `imagem do Docker` sem motivo (na verdade, esse problema pode ser resolvido compilando a imagem do Docker em uma imagem de Construtor especial antes de compilá-la, mas conversei com várias empresas e poucas equipes farão isso).
+
+## 2. Distribuir apenas o código JavaScript, baixar o produto correspondente na fase `postinstall`
+
+Algumas dependências de compilação de complementos nativos são tão complexas que não é prático para o desenvolvedor médio do Node instalar um conjunto completo de ferramentas de compilação durante a fase de desenvolvimento.
+Outro cenário é que o próprio complemento nativo é tão complexo que pode levar muito tempo para compilar, e o autor da biblioteca não gostaria que as pessoas passassem horas apenas instalando-a ao usar sua biblioteca.
+
+Então, outra maneira popular é usar as ferramentas de `CI` para **_pré-compilar_** o complemento nativo na tarefa de `CI` para cada plataforma (win32/darwin/linux/...) e distribuir apenas o código JavaScript correspondente,
+enquanto o arquivo do complemento **_pré-compilado_** é baixado do **CDN/lançamento do GitHub** por meio do script `postinstall`.
+Por exemplo, existe uma ferramenta popular na comunidade que faz isso: [node-pre-gyp](https://github.com/mapbox/node-pre-gyp). Esta ferramenta faz o upload automaticamente do complemento nativo compilado em `CI` para um local específico com base na configuração do usuário e, em seguida, o baixa do local de upload durante a instalação.
+
+Este método de distribuição parece impecável, mas existem vários problemas que não podem ser contornados:
+
+- Ferramentas como `node-pre-gyp` adicionam muitas dependências **irrelevantes em tempo de execução** a um projeto.
+- Não importa para qual `CDN` você faça o upload, é difícil acomodar usuários de todo o mundo. Você se lembra das memórias dolorosas de ficar preso em `postinstall` por horas para baixar arquivos de algum lançamento do GitHub e depois falhar? É verdade que construir um espelho binário na região mais próxima pode amenizar parcialmente esse problema, mas o espelho não está sempre sincronizado/faltando de tempos em tempos.
+- Não é amigável para redes privadas. Muitas empresas podem não conseguir acessar a extranet em suas máquinas de CI/CD (elas terão um NPM privado para acompanhar, mas se não tiverem, não adianta discutir), muito menos baixar um complemento nativo de algum CDN.
+
+## 3. O complemento nativo para diferentes plataformas é distribuído por meio de pacotes npm diferentes
+
+A nova ferramenta de compilação da geração [esbuild](https://github.com/evanw/esbuild), que é muito popular no front-end, usa essa abordagem. Cada complemento nativo corresponde a um pacote npm e, em seguida, o script `postinstall` instala o pacote do complemento nativo para o sistema atual.
+
+Outra maneira é expor os pacotes a serem instalados pelo usuário, usar todos os pacotes nativos como `optionalDependencies
+
+```json
+{
+  "name": "@node-rs/bcrypt",
+  "version": "0.5.0",
+  "os": ["linux", "win32", "darwin"],
+  "cpu": ["x64"],
+  "optionalDependencies": {
+    "@node-rs/bcrypt-darwin": "^0.5.0",
+    "@node-rs/bcrypt-linux": "^0.5.0",
+    "@node-rs/bcrypt-win32": "^0.5.0"
+  }
+}
+```
+
+```json
+{
+  "name": "@node-rs/bcrypt-darwin",
+  "version": "0.5.0",
+  "os": ["darwin"],
+  "cpu": ["x64"]
+}
+```
+
+```json
+{
+  "name": "@node-rs/bcrypt-linux",
+  "version": "0.5.0",
+  "os": ["linux"],
+  "cpu": ["x64"]
+}
+```
+
+```json
+{
+  "name": "@node-rs/bcrypt-win32",
+  "version": "0.5.0",
+  "os": ["win32"],
+  "cpu": ["x64"]
+}
+```
+
+Esta abordagem é a distribuição menos intrusiva para usuários que utilizam complementos nativos e é usada por [@ffmpeg-installer/ffmpeg](https://github.com/kribblo/node-ffmpeg-installer#readme).
+
+No entanto, essa abordagem impõe uma carga de trabalho adicional aos autores de complementos nativos, incluindo a necessidade de escrever ferramentas para gerenciar o binário de lançamento e um monte de pacotes, que geralmente são muito difíceis de depurar (e normalmente abrangem vários sistemas e arquiteturas de CPU).
+
+Essas ferramentas precisam gerenciar todo o fluxo do complemento através das fases de desenvolvimento -> versão de lançamento local -> CI -> artefatos -> fase de implantação. Além disso, há muitas configurações de CI/CD para escrever/depurar, o que é demorado e tedioso.
+
+## Conclusão
+
+O complemento nativo com o terceiro método de distribuição (**distribuição de complementos nativos para diferentes plataformas por meio de pacotes npm diferentes**) é o mais fácil de usar e o menos mentalmente cansativo para os desenvolvedores que o utilizam, mas esse método de distribuição impõe custos adicionais de manutenção aos autores de complementos nativos.
+
+Mais tarde, descreveremos como o `napi-rs` pode ajudar os desenvolvedores de complementos nativos a resolver o problema dos altos custos de manutenção de CI/CD com essa distribuição.
+
+{/* 采用第 3 种分发方式(**不同平台的 native addon 通过不同的 npm package 分发**)的 native addon 是最易用的，对于使用这个 native addon 的开发者来说他们的心智负担最小，但这种分发方式会给 native addon 的作者带来额外的维护成本。后面的内容我们会介绍 `napi-rs` 如何在这种分发方式下帮 native addon 的开发者们解决 CI/CD 维护成本比较高的问题。 */}

--- a/pages/docs/ecosystem/@napi-rs/_meta.pt-BR.json
+++ b/pages/docs/ecosystem/@napi-rs/_meta.pt-BR.json
@@ -1,0 +1,4 @@
+{
+  "canvas": "skr-canvas",
+  "pinyin": "@napi-rs/pinyin"
+}

--- a/pages/docs/ecosystem/@napi-rs/canvas.pt-BR.mdx
+++ b/pages/docs/ecosystem/@napi-rs/canvas.pt-BR.mdx
@@ -1,0 +1,361 @@
+---
+title: 'skr-canvas'
+description: Skia binding to Node.js.
+---
+
+# `skr-canvas`
+
+![CI](https://github.com/Brooooooklyn/canvas/workflows/CI/badge.svg)
+![Skia Version](https://img.shields.io/badge/Skia-chrome%2Fm98-hotpink)
+[![install size](https://packagephobia.com/badge?p=@napi-rs/canvas)](https://packagephobia.com/result?p=@napi-rs/canvas)
+[![Downloads](https://img.shields.io/npm/dm/@napi-rs/canvas.svg?sanitize=true)](https://npmcharts.com/compare/@napi-rs/canvas?minimal=true)
+
+> 🚀 Ajude-me a me tornar um desenvolvedor de código aberto em tempo integral, [patrocinando-me no Github](https://github.com/sponsors/Brooooooklyn)
+
+Binding do Google Skia para Node.js via [Node-API](https://napi.rs).
+
+⚠️ Este projeto está na fase de pré-lançamento. E podem existir alguns bugs.<br/>
+Para detalhes sobre os recursos planejados e direção futura, consulte o [Roadmap](https://github.com/Brooooooklyn/canvas/issues/113).
+
+## Instale
+
+```bash
+yarn add @napi-rs/canvas
+npm install @napi-rs/canvas
+```
+
+## Matriz de Suporte
+
+|                       | node10 | node12 | node14 | node16 |
+| --------------------- | ------ | ------ | ------ | ------ |
+| Windows x64           | ✓      | ✓      | ✓      | ✓      |
+| macOS x64             | ✓      | ✓      | ✓      | ✓      |
+| macOS aarch64         | ✓      | ✓      | ✓      | ✓      |
+| Linux x64 gnu         | ✓      | ✓      | ✓      | ✓      |
+| Linux x64 musl        | ✓      | ✓      | ✓      | ✓      |
+| Linux aarch64 gnu     | ✓      | ✓      | ✓      | ✓      |
+| Linux arm gnueabihf   | ✓      | ✓      | ✓      | ✓      |
+| Linux aarch64 android | ✓      | ✓      | ✓      | ✓      |
+
+## Uso
+
+```js
+const { promises } = require('fs')
+const { join } = require('path')
+
+const { createCanvas } = require('@napi-rs/canvas')
+
+const canvas = createCanvas(1024, 768)
+
+const ctx = canvas.getContext('2d')
+
+ctx.lineWidth = 10
+ctx.strokeStyle = '#03a9f4'
+ctx.fillStyle = '#03a9f4'
+
+// Wall
+ctx.strokeRect(75, 140, 150, 110)
+
+// Door
+ctx.fillRect(130, 190, 40, 60)
+
+// Roof
+ctx.beginPath()
+ctx.moveTo(50, 140)
+ctx.lineTo(150, 60)
+ctx.lineTo(250, 140)
+ctx.closePath()
+ctx.stroke()
+
+async function main() {
+  const pngData = await canvas.encode('png') // jpeg and webp is also supported
+  // encoding in libuv thread pool, non-blocking
+  await promises.writeFile(join(__dirname, 'simple.png'), pngData)
+}
+
+main()
+```
+
+![](./simple.png)
+
+### Emoji text
+
+```js
+const { writeFileSync } = require('fs')
+const { join } = require('path')
+
+const { createCanvas, GlobalFonts } = require('../index.js')
+
+GlobalFonts.registerFromPath(
+  join(__dirname, '..', 'fonts', 'AppleColorEmoji@2x.ttf'),
+  'Apple Emoji',
+)
+GlobalFonts.registerFromPath(
+  join(__dirname, '..', '__test__', 'fonts', 'COLRv1.ttf'),
+  'COLRv1',
+)
+
+console.info(GlobalFonts.families)
+
+const canvas = createCanvas(760, 360)
+const ctx = canvas.getContext('2d')
+
+ctx.font = '50px Apple Emoji'
+ctx.strokeText('😀😃😄😁😆😅😂🤣☺️😊😊😇', 50, 150)
+
+ctx.font = '100px COLRv1'
+ctx.fillText('abc', 50, 300)
+
+const b = canvas.toBuffer('image/png')
+
+writeFileSync(join(__dirname, 'draw-emoji.png'), b)
+```
+
+![](./draw-emoji.png)
+
+## Performance
+
+Veja [benchmark](https://github.com/Brooooooklyn/canvas/tree/main/benchmark) para o código de benchmark.
+
+Hardware info:
+
+```
+OS: Windows 10 x86_64
+Host: Micro-Star International Co., Ltd. MS-7C35
+Kernel: 10.0.19043
+Terminal: Windows Terminal
+CPU: AMD Ryzen 9 5950X (32) @ 3.400GHz
+Memory: 32688MiB
+```
+
+```text highlight={16,31}
+❯ pnpm bench
+
+> @napi-rs/canvas@0.0.9 bench D:\workspace\skia-rs
+> node -r @swc-node/register benchmark/bench.ts
+
+Running "Draw house" suite...
+Progress: 100%
+
+  skia-canvas:
+    26 ops/s, ±0.70%   | slowest, 29.73% slower
+
+  node-canvas:
+    30 ops/s, ±6.95%   | 18.92% slower
+
+  @napi-rs/skia:
+    37 ops/s, ±6.30%   | fastest
+
+Finished 3 cases!
+  Fastest: @napi-rs/skia
+  Slowest: skia-canvas
+Running "Draw gradient" suite...
+Progress: 100%
+
+  skia-canvas:
+    36 ops/s, ±6.12%   | 14.29% slower
+
+  node-canvas:
+    34 ops/s, ±5.60%   | slowest, 19.05% slower
+
+  @napi-rs/skia:
+    42 ops/s, ±0.53%   | fastest
+
+Finished 3 cases!
+  Fastest: @napi-rs/skia
+  Slowest: node-canvas
+```
+
+## Recursos
+
+### Path2D
+
+```typescript
+new Path2D()
+new Path2D(path: Path2D)
+// new Path2D('M108.956,403.826c0,0,0.178,3.344-1.276,3.311  c-1.455-0.033-30.507-84.917-66.752-80.957C40.928,326.18,72.326,313.197,108.956,403.826z')
+new Path2D(path: string)
+```
+
+```typescript
+export interface DOMMatrix2DInit {
+  a: number
+  b: number
+  c: number
+  d: number
+  e: number
+  f: number
+}
+
+export class Path2D {
+  constructor(path?: Path2D | string)
+
+  addPath(path: Path2D, transform?: DOMMatrix2DInit): void
+  arc(
+    x: number,
+    y: number,
+    radius: number,
+    startAngle: number,
+    endAngle: number,
+    anticlockwise?: boolean,
+  ): void
+  arcTo(x1: number, y1: number, x2: number, y2: number, radius: number): void
+  bezierCurveTo(
+    cp1x: number,
+    cp1y: number,
+    cp2x: number,
+    cp2y: number,
+    x: number,
+    y: number,
+  ): void
+  closePath(): void
+  ellipse(
+    x: number,
+    y: number,
+    radiusX: number,
+    radiusY: number,
+    rotation: number,
+    startAngle: number,
+    endAngle: number,
+    anticlockwise?: boolean,
+  ): void
+  lineTo(x: number, y: number): void
+  moveTo(x: number, y: number): void
+  quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): void
+  rect(x: number, y: number, w: number, h: number): void
+
+  // PathKit methods
+  op(path: Path2D, operation: PathOp): Path2D
+  toSVGString(): string
+  getFillType(): FillType
+  getFillTypeString(): string
+  setFillType(type: FillType): void
+  simplify(): Path2D
+  asWinding(): Path2D
+  stroke(stroke?: StrokeOptions): Path2D
+  transform(transform: DOMMatrix2DInit): Path2D
+  getBounds(): [left: number, top: number, right: number, bottom: number]
+  computeTightBounds(): [
+    left: number,
+    top: number,
+    right: number,
+    bottom: number,
+  ]
+  trim(start: number, end: number, isComplement?: boolean): Path2D
+  equals(path: Path2D): boolean
+}
+```
+
+### PathKit
+
+`PathKit` é um conjunto de ferramentas para manipular Path no `Skia`, que suporta **curvas de Bezier quadráticas**, **curvas de Bezier cúbicas** e **cônicas**.
+As principais são:
+
+### Path Operation
+
+`.op(path, PathOp)`
+
+```js
+const pathOne = new Path2D(
+  'M8 50H92C96.4183 50 100 53.5817 100 58V142C100 146.418 96.4183 150 92 150H8C3.58172 150 0 146.418 0 142V58C0 53.5817 3.58172 50 8 50Z',
+)
+const pathTwo = new Path2D(
+  '"M58 0H142C146.418 0 150 3.58172 150 8V92C150 96.4183 146.418 100 142 100H58C53.5817 100 50 96.4183 50 92V8C50 3.58172 53.5817 0 58 0Z',
+)
+
+pathOne.op(pathTwo, PathOp.Intersect).toSVGString()
+// => "M100 100L58 100C53.5817 100 50 96.4183 50 92L50 50L92 50C96.4183 50 100 53.5817 100 58L100 100Z"
+```
+
+- **Union**, subtrai o caminho de operação do primeiro caminho.
+- **Difference**, intersecta os dois caminhos.
+- **ReverseDifference**, une (inclusive ou) os dois caminhos.
+- **Intersect**, ou-exclusivo dos dois caminhos.
+- **XOR**, subtrai o primeiro caminho do caminho de operação.
+
+![](/assets/boolean-operations.svg)
+
+#### Converter `FillType` em **_Path_**
+
+`.asWinding()`
+
+Você pode converter `fill-rule="evenodd"` para `fill-rule="nonzero"` em SVG.
+Isso é útil para ferramentas relacionadas a fontes **OpenType**, já que `fill-rule="nonzero"` é suportado apenas em fontes **OpenType**.
+
+```js
+const pathCircle = new Path2D(
+  'M50 87.5776C70.7536 87.5776 87.5776 70.7536 87.5776 50C87.5776 29.2464 70.7536 12.4224 50 12.4224C29.2464 12.4224 12.4224 29.2464 12.4224 50C12.4224 70.7536 29.2464 87.5776 50 87.5776ZM50 100C77.6142 100 100 77.6142 100 50C100 22.3858 77.6142 0 50 0C22.3858 0 0 22.3858 0 50C0 77.6142 22.3858 100 50 100Z',
+)
+pathCircle.setFillType(FillType.EvenOdd)
+pathCircle.asWinding().toSVGString()
+// => "M50 87.5776C29.2464 87.5776 12.4224 70.7536 12.4224 50C12.4224 29.2464 29.2464 12.4224 50 12.4224C70.7536 12.4224 87.5776 29.2464 87.5776 50C87.5776 70.7536 70.7536 87.5776 50 87.5776ZM50 100C77.6142 100 100 77.6142 100 50C100 22.3858 77.6142 0 50 0C22.3858 0 0 22.3858 0 50C0 77.6142 22.3858 100 50 100Z"
+```
+
+#### Simplificar **_Path_**
+
+`.simplify()`
+
+Define o caminho para o mesmo contorno não sobreposto da área de caminho original, o que significa que também pode remover caminhos sobrepostos.
+
+![](./simplify.png)
+
+[SVG com caminhos sobrepostos](./overlapping-path.svg) (Left)
+
+```js
+const path =
+  'M2.933,89.89 L89.005,3.818 Q90.412,2.411 92.249,1.65 Q94.087,0.889 96.076,0.889 Q98.065,0.889 99.903,1.65 Q101.741,2.411 103.147,3.818 L189.22,89.89 Q190.626,91.296 191.387,93.134 Q192.148,94.972 192.148,96.961 Q192.148,98.95 191.387,100.788 Q190.626,102.625 189.219,104.032 Q187.813,105.439 185.975,106.2 Q184.138,106.961 182.148,106.961 Q180.159,106.961 178.322,106.2 Q176.484,105.439 175.077,104.032 L89.005,17.96 L96.076,10.889 L103.147,17.96 L17.075,104.032 Q15.668,105.439 13.831,106.2 Q11.993,106.961 10.004,106.961 Q8.015,106.961 6.177,106.2 Q4.339,105.439 2.933,104.032 Q1.526,102.625 0.765,100.788 Q0.004,98.95 0.004,96.961 Q0.004,94.972 0.765,93.134 Q1.526,91.296 2.933,89.89 Z'
+
+path.simplify().toSVGString()
+// => "M89.005 3.818L2.933 89.89Q1.526 91.296 0.765 93.134Q0.004 94.972 0.004 96.961Q0.004 98.95 0.765 100.788Q1.526 102.625 2.933 104.032Q4.339 105.439 6.177 106.2Q8.015 106.961 10.004 106.961Q11.993 106.961 13.831 106.2Q15.668 105.439 17.075 104.032L96.076 25.031L175.077 104.032Q176.484 105.439 178.322 106.2Q180.159 106.961 182.148 106.961Q184.138 106.961 185.975 106.2Q187.813 105.439 189.219 104.032Q190.626 102.625 191.387 100.788Q192.148 98.95 192.148 96.961Q192.148 94.972 191.387 93.134Q190.626 91.296 189.22 89.89L103.147 3.818Q101.741 2.411 99.903 1.65Q98.065 0.889 96.076 0.889Q94.087 0.889 92.249 1.65Q90.412 2.411 89.005 3.818Z"
+```
+
+## [Exemplo](https://github.com/Brooooooklyn/canvas/blob/main/example/tiger.js)
+
+> O arquivo tiger.json foi serializado de [gojs/samples/tiger](https://github.com/NorthwoodsSoftware/GoJS/blob/master/samples/tiger.html)
+
+![](./tiger.png)
+
+## Building
+
+## Compilar o skia a partir do código-fonte
+
+Você pode compilar este projeto a partir do código-fonte, sem a necessidade de comandos específicos do sistema operacional para instalar pacotes:
+
+```sh
+# Clone the code:
+$ git clone --recurse-submodules https://github.com/Brooooooklyn/canvas.git
+$ cd canvas
+
+# Build Skia:
+$ node scripts/build-skia.js
+
+# Install NPM packages, build the Node.js addon:
+$ yarn install --ignore-scripts
+$ yarn build
+
+# All done! Run test cases or examples now:
+$ yarn test
+$ node example/tiger.js
+```
+
+## Obter binários pré-compilados do Skia no GitHub
+
+Você pode obter binários pré-compilados do Skia se estiver interessado apenas na parte `Rust`:
+
+```sh
+# Clone the code:
+$ git clone --recurse-submodules https://github.com/Brooooooklyn/canvas.git
+$ cd canvas
+
+# Download Skia binaries:
+# It will pull the binaries match the git hash in `./skia` submodule
+$ node scripts/release-skia-binary.js --download
+
+# Install NPM packages, build the Node.js addon:
+$ yarn install --ignore-scripts
+$ yarn build
+
+# All done! Run test cases or examples now:
+$ yarn test
+$ node example/tiger.js
+```

--- a/pages/docs/ecosystem/@napi-rs/pinyin.pt-BR.mdx
+++ b/pages/docs/ecosystem/@napi-rs/pinyin.pt-BR.mdx
@@ -1,0 +1,89 @@
+---
+description: rust-pinyin binding to Node.js.
+---
+
+# @napi-rs/pinyin
+
+<a href="https://www.npmjs.com/package/@napi-rs/pinyin" target="_blank">
+  <img
+    alt="npm Downloads"
+    src="https://img.shields.io/npm/dm/@napi-rs/pinyin"
+  />
+</a>
+<a href="https://github.com/Brooooooklyn/pinyin" target="_blank">
+  <img
+    alt="Github stars"
+    src="https://img.shields.io/github/stars/Brooooooklyn/pinyin?style=social"
+  />
+</a>
+
+> Binding do [rust-pinyin](https://github.com/mozillazg/rust-pinyin) para Node.js.
+
+## Performance
+
+**Hardware info**:
+
+```
+Model Name: MacBook Pro
+Model Identifier: MacBookPro15,1
+Processor Name: 6-Core Intel Core i7
+Processor Speed: 2.6 GHz
+Number of Processors: 1
+Total Number of Cores: 6
+L2 Cache (per Core): 256 KB
+L3 Cache: 12 MB
+Hyper-Threading Technology: Enabled
+Memory: 16 GB
+```
+
+```bash {8,19}
+Running "Short input without segment" suite...
+Progress: 100%
+
+  @napi-rs/pinyin:
+    962 035 ops/s, ±0.68%   | fastest
+
+  node-pinyin:
+    434 241 ops/s, ±0.66%   | slowest, 54.86% slower
+
+Finished 2 cases!
+  Fastest: @napi-rs/pinyin
+  Slowest: node-pinyin
+Running "Long input without segment" suite...
+Progress: 100%
+
+  @napi-rs/pinyin:
+    59 ops/s, ±0.83%   | fastest
+
+  node-pinyin:
+    2 ops/s, ±3.30%    | slowest, 96.61% slower
+
+Finished 2 cases!
+  Fastest: @napi-rs/pinyin
+  Slowest: node-pinyin
+Running "Short input with segment" suite...
+Progress: 100%
+
+  @napi-rs/pinyin:
+    530 228 ops/s, ±1.94%   | fastest
+
+  node-pinyin:
+    307 788 ops/s, ±0.83%   | slowest, 41.95% slower
+
+Finished 2 cases!
+  Fastest: @napi-rs/pinyin
+  Slowest: node-pinyin
+Running "Long input with segment" suite...
+Progress: 100%
+
+  @napi-rs/pinyin:
+    152 ops/s, ±1.09%   | fastest
+
+  node-pinyin:
+    3 ops/s, ±3.08%     | slowest, 98.03% slower
+
+Finished 2 cases!
+  Fastest: @napi-rs/pinyin
+  Slowest: node-pinyin
+✨  Done in 53.36s.
+```

--- a/pages/docs/ecosystem/@node-rs/_meta.pt-BR.json
+++ b/pages/docs/ecosystem/@node-rs/_meta.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "bcrypt": "@node-rs/bcrypt",
+  "crc32": "@node-rs/crc32",
+  "deno-lint": "@node-rs/deno-lint",
+  "jieba": "@node-rs/jieba"
+}

--- a/pages/docs/ecosystem/@node-rs/bcrypt.pt-BR.mdx
+++ b/pages/docs/ecosystem/@node-rs/bcrypt.pt-BR.mdx
@@ -1,0 +1,68 @@
+---
+description: Fast and safe bcrypt implementation in Node.js.
+---
+
+# @node-rs/bcrypt
+
+<a href="https://www.npmjs.com/package/@node-rs/bcrypt" target="_blank">
+  <img
+    alt="npm Downloads"
+    src="https://img.shields.io/npm/dm/@node-rs/bcrypt"
+  />
+</a>
+<a href="https://github.com/napi-rs/node-rs" target="_blank">
+  <img
+    alt="GitHub stars"
+    src="https://img.shields.io/github/stars/napi-rs/node-rs?style=social"
+  />
+</a>
+
+> Implementação rápida e segura do bcrypt em Node.js.
+
+## Performance
+
+**Hardware info**:
+
+```
+Model Name: MacBook Pro
+Model Identifier: MacBookPro15,1
+Processor Name: 6-Core Intel Core i7
+Processor Speed: 2.6 GHz
+Number of Processors: 1
+Total Number of Cores: 6
+L2 Cache (per Core): 256 KB
+L3 Cache: 12 MB
+Hyper-Threading Technology: Enabled
+Memory: 16 GB
+```
+
+```bash {4,8,12,16,20,24,28}
+@node-rs/bcrypt x 70.38 ops/sec ±1.40% (32 runs sampled)
+node bcrypt x 63.88 ops/sec ±0.95% (30 runs sampled)
+bcryptjs x 12.23 ops/sec ±4.90% (10 runs sampled)
+Async hash round 10 bench suite: Fastest is @node-rs/bcrypt
+@node-rs/bcrypt x 16.55 ops/sec ±2.33% (11 runs sampled)
+node bcrypt x 14.62 ops/sec ±1.48% (11 runs sampled)
+bcryptjs x 3.12 ops/sec ±1.60% (6 runs sampled)
+Async hash round 12 bench suite: Fastest is @node-rs/bcrypt
+@node-rs/bcrypt x 3.65 ops/sec ±5.08% (6 runs sampled)
+node bcrypt x 3.50 ops/sec ±2.14% (6 runs sampled)
+bcryptjs x 0.84 ops/sec ±12.31% (5 runs sampled)
+Async hash round 14 bench suite: Fastest is @node-rs/bcrypt
+@node-rs/bcrypt x 18.78 ops/sec ±0.86% (12 runs sampled)
+node bcrypt x 16.28 ops/sec ±3.55% (11 runs sampled)
+bcryptjs x 3.70 ops/sec ±2.64% (6 runs sampled)
+Async verify bench suite: Fastest is @node-rs/bcrypt
+@node-rs/bcrypt x 19.24 ops/sec ±1.67% (52 runs sampled)
+node bcrypt x 17.53 ops/sec ±0.38% (47 runs sampled)
+bcryptjs x 14.71 ops/sec ±2.18% (41 runs sampled)
+Hash round 10 bench suite: Fastest is @node-rs/bcrypt
+@node-rs/bcrypt x 4.79 ops/sec ±1.92% (16 runs sampled)
+node bcrypt x 4.26 ops/sec ±2.43% (15 runs sampled)
+bcryptjs x 3.76 ops/sec ±1.90% (14 runs sampled)
+Hash round 12 bench suite: Fastest is @node-rs/bcrypt
+@node-rs/bcrypt x 1.19 ops/sec ±2.27% (7 runs sampled)
+node bcrypt x 1.00 ops/sec ±4.71% (7 runs sampled)
+bcryptjs x 0.93 ops/sec ±5.60% (7 runs sampled)
+Hash round 14 bench suite: Fastest is @node-rs/bcrypt
+```

--- a/pages/docs/ecosystem/@node-rs/crc32.pt-BR.mdx
+++ b/pages/docs/ecosystem/@node-rs/crc32.pt-BR.mdx
@@ -1,0 +1,60 @@
+---
+description: Fastest crc32 implementation in Node.js.
+---
+
+# @node-rs/crc32
+
+<a href="https://www.npmjs.com/package/@node-rs/crc32" target="_blank">
+  <img alt="npm Downloads" src="https://img.shields.io/npm/dm/@node-rs/crc32" />
+</a>
+<a href="https://github.com/napi-rs/node-rs" target="_blank">
+  <img
+    alt="Github stars"
+    src="https://img.shields.io/github/stars/napi-rs/node-rs?style=social"
+  />
+</a>
+
+> Implementação rápida e segura de crc32 em Node.js.
+
+## Performance
+
+**Hardware info**:
+
+```
+Model Name: MacBook Pro
+Model Identifier: MacBookPro15,1
+Processor Name: 6-Core Intel Core i7
+Processor Speed: 2.6 GHz
+Number of Processors: 1
+Total Number of Cores: 6
+L2 Cache (per Core): 256 KB
+L3 Cache: 12 MB
+Hyper-Threading Technology: Enabled
+Memory: 16 GB
+```
+
+```bash highlight={14}
+@node-rs/crc32 for inputs 1024B x 5,108,123 ops/sec ±1.86% (89 runs sampled)
+@node-rs/crc32 for inputs 16931844B, avg 2066B x 271 ops/sec ±1.15% (85 runs sampled)
+sse4_crc32c_hw for inputs 1024B x 3,543,443 ops/sec ±1.39% (93 runs sampled)
+sse4_crc32c_hw for inputs 16931844B, avg 2066B x 209 ops/sec ±0.78% (76 runs sampled)
+sse4_crc32c_sw for inputs 1024B x 1,460,284 ops/sec ±2.35% (90 runs sampled)
+sse4_crc32c_sw for inputs 16931844B, avg 2066B x 93.50 ops/sec ±2.43% (69 runs sampled)
+js_crc32c for inputs 1024B x 464,681 ops/sec ±0.46% (91 runs sampled)
+js_crc32c for inputs 16931844B, avg 2066B x 28.25 ops/sec ±1.64% (51 runs sampled)
+js_crc32 for inputs 1024B x 442,272 ops/sec ±2.66% (93 runs sampled)
+js_crc32 for inputs 16931844B, avg 2066B x 22.12 ops/sec ±5.20% (40 runs sampled)
++---------------------+-------------------+----------------------+
+|                     │ 1024B             │ 16931844B, avg 2066B |
++---------------------+-------------------+----------------------+
+| @node-rs/crc32      │ 5,108,123 ops/sec │ 271 ops/sec          |
++---------------------+-------------------+----------------------+
+| sse4_crc32c_hw      │ 3,543,443 ops/sec │ 209 ops/sec          |
++---------------------+-------------------+----------------------+
+| sse4_crc32c_sw      │ 1,460,284 ops/sec │ 93.50 ops/sec        |
++---------------------+-------------------+----------------------+
+| js_crc32c           │ 464,681 ops/sec   │ 28.25 ops/sec        |
++---------------------+-------------------+----------------------+
+| js_crc32            │ 442,272 ops/sec   │ 22.12 ops/sec        |
++---------------------+-------------------+----------------------+
+```

--- a/pages/docs/ecosystem/@node-rs/deno-lint.pt-BR.mdx
+++ b/pages/docs/ecosystem/@node-rs/deno-lint.pt-BR.mdx
@@ -1,0 +1,45 @@
+---
+description: deno_lint binding to Node.js.
+---
+
+# @node-rs/deno-lint
+
+> WIP
+
+<a href="https://www.npmjs.com/package/@node-rs/deno-lint" target="_blank">
+  <img
+    alt="npm Downloads"
+    src="https://img.shields.io/npm/dm/@node-rs/deno-lint"
+  />
+</a>
+<a href="https://github.com/napi-rs/node-rs" target="_blank">
+  <img
+    alt="GitHub stars"
+    src="https://img.shields.io/github/stars/napi-rs/node-rs?style=social"
+  />
+</a>
+
+> Binding [deno_lint](https://github.com/denoland/deno_lint) para Node.js.
+
+## Performance
+
+**Hardware info**:
+
+```
+Model Name: MacBook Pro
+Model Identifier: MacBookPro15,1
+Processor Name: 6-Core Intel Core i7
+Processor Speed: 2.6 GHz
+Number of Processors: 1
+Total Number of Cores: 6
+L2 Cache (per Core): 256 KB
+L3 Cache: 12 MB
+Hyper-Threading Technology: Enabled
+Memory: 16 GB
+```
+
+```bash highlight={3}
+@node-rs/deno-lint x 885 ops/sec ±1.26% (92 runs sampled)
+eslint x 118 ops/sec ±4.97% (78 runs sampled)
+Lint benchmark bench suite: Fastest is @node-rs/deno-lint
+```

--- a/pages/docs/ecosystem/@node-rs/jieba.pt-BR.mdx
+++ b/pages/docs/ecosystem/@node-rs/jieba.pt-BR.mdx
@@ -1,0 +1,52 @@
+---
+description: jieba-rs binding to Node.js.
+---
+
+# @node-rs/jieba
+
+<a href="https://www.npmjs.com/package/@node-rs/jieba" target="_blank">
+  <img alt="npm Downloads" src="https://img.shields.io/npm/dm/@node-rs/jieba" />
+</a>
+<a href="https://github.com/napi-rs/node-rs" target="_blank">
+  <img
+    alt="GitHub stars"
+    src="https://img.shields.io/github/stars/napi-rs/node-rs?style=social"
+  />
+</a>
+
+> Binding [jieba-rs](https://github.com/messense/jieba-rs) para Node.js.
+
+## Performance
+
+**Hardware info**:
+
+```
+Model Name: MacBook Pro
+Model Identifier: MacBookPro15,1
+Processor Name: 6-Core Intel Core i7
+Processor Speed: 2.6 GHz
+Number of Processors: 1
+Total Number of Cores: 6
+L2 Cache (per Core): 256 KB
+L3 Cache: 12 MB
+Hyper-Threading Technology: Enabled
+Memory: 16 GB
+```
+
+```bash {3,7,11,15}
+@node-rs/jieba x 3,763 ops/sec ±1.18% (92 runs sampled)
+nodejieba x 2,783 ops/sec ±0.67% (91 runs sampled)
+Cut 1184 words bench suite: Fastest is @node-rs/jieba
+
+@node-rs/jieba x 16.10 ops/sec ±1.58% (44 runs sampled)
+nodejieba x 9.81 ops/sec ±2.39% (29 runs sampled)
+Cut 246568 words bench suite: Fastest is @node-rs/jieba
+
+@node-rs/jieba x 1,739 ops/sec ±0.87% (92 runs sampled)
+nodejieba x 931 ops/sec ±1.31% (89 runs sampled)
+Tag 1184 words bench suite: Fastest is @node-rs/jieba
+
+@node-rs/jieba x 6.19 ops/sec ±2.01% (20 runs sampled)
+nodejieba x 3.06 ops/sec ±5.39% (12 runs sampled)
+Tag 246568 words bench suite: Fastest is @node-rs/jieba
+```

--- a/pages/docs/ecosystem/_meta.pt-BR.json
+++ b/pages/docs/ecosystem/_meta.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "snappy": "snappy",
+  "swc": "swc",
+  "@napi-rs": "@napi-rs",
+  "@node-rs": "@node-rs"
+}

--- a/pages/docs/ecosystem/snappy.pt-BR.mdx
+++ b/pages/docs/ecosystem/snappy.pt-BR.mdx
@@ -1,0 +1,114 @@
+---
+description: Fastest Snappy compression library in Node.js.
+---
+
+# snappy
+
+![https://github.com/Brooooooklyn/snappy/actions](https://github.com/Brooooooklyn/snappy/workflows/CI/badge.svg)
+![](https://img.shields.io/npm/dm/snappy.svg?sanitize=true)
+[![Install size](https://packagephobia.com/badge?p=snappy)](https://packagephobia.com/result?p=snappy)
+
+**!!! Para `snappy@6.x` e abaixo, por favor, vá para [`node-snappy`](https://github.com/kesla/node-snappy).**
+
+Para mais informações sobre as mudanças **6-7**, por favor, leia [isto](https://github.com/Brooooooklyn/snappy/issues/16), Obrigado [@kesla](https://github.com/kesla).
+
+> 🚀 Ajude-me a me tornar um desenvolvedor de código aberto em tempo integral patrocinando-me no Github](https://github.com/sponsors/Brooooooklyn)
+
+Biblioteca de compressão Snappy mais rápida em Node.js, alimentada por [napi-rs](https://napi.rs) e [rust-snappy](https://github.com/BurntSushi/rust-snappy).
+
+> Para dados de tamanho pequeno, [snappyjs](https://github.com/zhipeng-jia/snappyjs) é mais rápido, e suporta navegador. Mas não possui API assíncrona, o que é importante para programas Node.js.
+
+## Instalar este pacote
+
+```
+yarn add snappy
+```
+
+## Matriz de Suporte
+
+|                  | node12 | node14 | node16 |
+| ---------------- | ------ | ------ | ------ |
+| Windows x64      | ✓      | ✓      | ✓      |
+| Windows x32      | ✓      | ✓      | ✓      |
+| Windows arm64    | ✓      | ✓      | ✓      |
+| macOS x64        | ✓      | ✓      | ✓      |
+| macOS arm64      | ✓      | ✓      | ✓      |
+| Linux x64 gnu    | ✓      | ✓      | ✓      |
+| Linux x64 musl   | ✓      | ✓      | ✓      |
+| Linux arm gnu    | ✓      | ✓      | ✓      |
+| Linux arm64 gnu  | ✓      | ✓      | ✓      |
+| Linux arm64 musl | ✓      | ✓      | ✓      |
+| Android arm64    | ✓      | ✓      | ✓      |
+| FreeBSD x64      | ✓      | ✓      | ✓      |
+
+## API
+
+```ts
+export function compressSync(
+  input: Buffer | string | ArrayBuffer | Uint8Array,
+): Buffer
+export function compress(
+  input: Buffer | string | ArrayBuffer | Uint8Array,
+): Promise<Buffer>
+export function uncompressSync(compressed: Buffer): Buffer
+export function uncompress(compressed: Buffer): Promise<Buffer>
+```
+
+## Performance
+
+### Hardware
+
+```text
+Model Name: MacBook Pro
+Model Identifier: MacBookPro15,1
+Processor Name: 6-Core Intel Core i7
+Processor Speed: 2.6 GHz
+Number of Processors: 1
+Total Number of Cores: 6
+L2 Cache (per Core): 256 KB
+L3 Cache: 12 MB
+Hyper-Threading Technology: Enabled
+Memory: 16 GB
+```
+
+### Result
+
+```text highlight={5,24}
+Running "Compress" suite...
+Progress: 25%
+
+  snappy:
+    1 426 ops/s, ±2.26%
+
+  gzip:
+    152 ops/s, ±1.54%
+
+  deflate:
+    155 ops/s, ±2.14%
+
+  brotli:
+    3 ops/s, ±3.43%       | slowest, 99.79% slower
+
+Finished 4 cases!
+  Fastest: snappy
+  Slowest: brotli
+
+Running "Decompress" suite...
+Progress: 25%
+
+  snappy:
+    2 771 ops/s, ±1.13%
+
+  gzip:
+    854 ops/s, ±6.99%
+
+  deflate:
+    877 ops/s, ±3.19%
+
+  brotli:
+    638 ops/s, ±2.31%     | slowest, 76.98% slower
+
+Finished 4 cases!
+  Fastest: snappy
+  Slowest: brotli
+```

--- a/pages/docs/ecosystem/swc.pt-BR.mdx
+++ b/pages/docs/ecosystem/swc.pt-BR.mdx
@@ -1,0 +1,66 @@
+---
+description: swc is a super-fast typescript / javascript compiler written in rust.
+---
+
+# swc
+
+<a href="https://www.npmjs.com/package/@swc/core" target="_blank">
+  <img alt="npm Downloads" src="https://img.shields.io/npm/dm/@swc/core" />
+</a>
+<a href="https://github.com/swc-project/swc" target="_blank">
+  <img
+    alt="GitHub stars"
+    src="https://img.shields.io/github/stars/swc-project/swc?style=social"
+  />
+</a>
+
+<br />
+<br />
+
+> O swc é um compilador TypeScript / JavaScript super rápido escrito em Rust.
+
+## Performance
+
+> ⚠️ Observação: A API `transformSync` no esbuild tem uma grande sobrecarga. Portanto, o `swc` é apenas mais rápido que o esbuild na API `transformSync`. Na API `transform`, o `esbuild` é cerca de **1 ~ 1,6x mais rápido** que o `swc`. <br/>
+> Transforme o `AjaxObservable.ts` do RxJS em JavaScript ES2015 & CommonJS. Código de benchmark: [bench](https://github.com/Brooooooklyn/swc-node/blob/master/bench/index.ts)
+
+**Hardware info**:
+
+```
+Model Name: MacBook Pro
+Model Identifier: MacBookPro15,1
+Processor Name: 6-Core Intel Core i7
+Processor Speed: 2.6 GHz
+Number of Processors: 1
+Total Number of Cores: 6
+L2 Cache (per Core): 256 KB
+L3 Cache: 12 MB
+Hyper-Threading Technology: Enabled
+Memory: 16 GB
+```
+
+### `transformSync`
+
+```text {1}
+@swc/core x 368 ops/sec ±4.18% (84 runs sampled)
+esbuild x 42.16 ops/sec ±1.76% (55 runs sampled)
+typescript x 24.52 ops/sec ±14.38% (51 runs sampled)
+babel x 22.08 ops/sec ±10.17% (44 runs sampled)
+Transform rxjs/AjaxObservable.ts benchmark bench suite: Fastest is @swc/core
+```
+
+### `transform` single thread
+
+```text {2}
+@swc/core x 291 ops/sec ±1.66% (78 runs sampled)
+esbuild x 454 ops/sec ±3.66% (73 runs sampled)
+Transform rxjs/AjaxObservable.ts async benchmark bench suite: Fastest is esbuild
+```
+
+### `transform` parallel
+
+```text {1-2}
+@swc/core x 946 ops/sec ±2.36% (74 runs sampled)
+esbuild x 931 ops/sec ±3.56% (65 runs sampled)
+Transform rxjs/AjaxObservable.ts parallel benchmark bench suite: Fastest is @swc-node/core,esbuild
+```

--- a/pages/docs/introduction/_meta.pt-BR.json
+++ b/pages/docs/introduction/_meta.pt-BR.json
@@ -1,0 +1,4 @@
+{
+  "getting-started": "Começando",
+  "simple-package": "Um pacote simples"
+}

--- a/pages/docs/introduction/getting-started.pt-BR.mdx
+++ b/pages/docs/introduction/getting-started.pt-BR.mdx
@@ -1,0 +1,194 @@
+---
+title: 'Começando'
+description: Aprenda como começar com o napi-rs.
+---
+
+# Começando
+
+import Video from '../../../public/assets/napi-rs-guide.mp4'
+
+## Comece com `@napi-rs/cli`
+
+> A Maneira recomendada.
+
+<br />
+
+<video controls style={{ width: '100%' }}>
+  <source src={Video} type="video/mp4" />
+  <track kind="captions" srcLang="en" />
+</video>
+
+### Instale a cli
+
+```bash
+yarn global add @napi-rs/cli
+# or
+npm install -g @napi-rs/cli
+# or
+pnpm add -g @napi-rs/cli
+```
+
+### Crie um projeto
+
+```bash
+napi new
+```
+
+#### Nome do pacote
+
+O campo name no `package.json`.
+
+#### Escolha os alvos que deseja suportar
+
+Plataformas que você desejar dar suporte.
+
+#### Habilite GitHub actions
+
+Gere a configuração do GitHub actions para você.
+
+### Aprofundamento
+
+Aqui é recomendado distribuir seu pacote sob [escopo npm](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages/) porque `@napi-rs/cli` por padrão, anexa os diferentes sufixos de plataforma ao nome do pacote npm como o nome do pacote para a distribuição binária de plataforma diferente. O uso do escopo npm reduzirá a chance de o nome do pacote já estar em uso.
+
+Por exemplo, se você quiser publicar o pacote `@cool/core`, com suporte para `macOS x64`, `Windows x64` e `Linux aarch64`, o `@napi-rs/cli` criará e publicará quatro pacotes para você:
+
+- `@cool/core` inclue apenas códigos `JavaScript`, que na verdade carregam o binário nativo de cada plataforma.
+- `@cool/core-darwin-x64` para a plataforma `macOS x64`.
+- `@cool/core-win32-x64` para a plataforma `Windows x64`.
+- `@cool/core-linux-arm64-gnu` para a plataforma `Linux aarch64`.
+
+Em cada pacote binário de plataforma, há os campos `cpu` e `os` em seu `package.json`:
+
+```json filename="package.json"
+{
+  "name": "@cool/core-darwin-x64",
+  "version": "1.0.0",
+  "os": ["darwin"],
+  "cpu": ["x64"]
+}
+```
+
+E `@cool/core` utiliza esses pacotes nativos como `optionalDependencies`:
+
+```json filename="package.json"
+{
+  "name": "@cool/core",
+  "version": "1.0.0",
+  "optionalDependencies": {
+    "@cool/core-darwin-x64": "^1.0.0",
+    "@cool/core-win32-x64": "^1.0.0",
+    "@cool/core-linux-arm64": "^1.0.0"
+  }
+}
+```
+
+E seu `index.js` em `@cool/core` será isso:
+
+```js filename="index.js"
+const { existsSync, readFileSync } = require('fs')
+const { join } = require('path')
+
+const { platform, arch } = process
+
+let nativeBinding = null
+let localFileExisted = false
+let isMusl = false
+let loadError = null
+
+switch (platform) {
+  case 'darwin':
+    switch (arch) {
+      case 'x64':
+        localFileExisted = existsSync(join(__dirname, 'core.darwin-x64.node'))
+        try {
+          if (localFileExisted) {
+            nativeBinding = require('./core.darwin-x64.node')
+          } else {
+            nativeBinding = require('@cool/core-darwin-x64')
+          }
+        } catch (e) {
+          loadError = e
+        }
+        break
+      case 'arm64':
+        localFileExisted = existsSync(join(__dirname, 'core.darwin-arm64.node'))
+        try {
+          if (localFileExisted) {
+            nativeBinding = require('./core.darwin-arm64.node')
+          } else {
+            nativeBinding = require('@cool/core-darwin-arm64')
+          }
+        } catch (e) {
+          loadError = e
+        }
+        break
+      default:
+        throw new Error(`Unsupported architecture on macOS: ${arch}`)
+    }
+    break
+  // ...
+  default:
+    throw new Error(`Unsupported OS: ${platform}, architecture: ${arch}`)
+}
+
+if (!nativeBinding) {
+  if (loadError) {
+    throw loadError
+  }
+  throw new Error(`Failed to load native binding`)
+}
+
+const { plus100 } = nativeBinding
+
+module.exports.plus100 = plus100
+```
+
+O arquivo `index.js` gerado ajudará você a carregar o arquivo binário **_correto_** onde quer que esteja. E o `index.js` lida com dois casos:
+
+#### Pacote instalado nos `node_modules` dos usuários
+
+Para carregar o binário correto, a função `index.js` tenta carregar todos os pacotes possíveis para essa plataforma (pode haver vários pacotes binários possíveis para uma determinada arquitetura de sistema e CPU), por exemplo, na plataforma `Linux x64`, `index.js` tenta carregar `@cool/core-linux-x64-gnu` e `@cool/core-linux-x64-musl`. O pacote `@cool/core-linux-x64-gnu` será carregado se o usuário estiver usando um sistema operacional como `Ubuntu` `Debian` com `gnu libc` pré-instalado. E se o usuário estiver usando um sistema operacional como `Alpine` com `musl libc` pré-instalado, então `@cool/core-linux-x64-musl` será carregado.
+
+#### Desenvolvimento local
+
+O comando `build` no package.json no projeto gerado pelo comando `@napi-rs/cli` irá gerar a biblioteca de vínculo dinâmico binária compilada a partir do código `Rust` no diretório atual para fins de depuração. `index.js` também tentará carregar o binário correspondente do diretório atual nesse caso. Novamente, usando `Linux x64` como exemplo, a função `index.js` tentará carregar os arquivos `core.linux-x64-gnu.node` e `core.linux-x64-musl.node` sucessivamente.
+
+#### Problema de suporte ao IDE
+
+Caso sua IDE se recusa a autocompletar/surgerir automaticamente código ao usar o macro `#[napi]`, você pode usar a seguinte configuração para corrigir isso:
+
+Para vscode em `settings.json`:
+
+```json
+{
+  "rust-analyzer.procMacro.ignored": { "napi-derive": ["napi"] }
+}
+```
+
+Para Neovim.
+
+```toml
+['rust-analyzer'] = {
+    procMacro = {
+        ignored = {
+            ['napi-derive'] = { 'napi' },
+        },
+    },
+},
+```
+
+Este problema pode emitir o seguinte erro no Rust Analyzer:
+
+```
+[ERROR proc_macro_api::msg] proc-macro tried to print : `napi` macro expand failed.
+```
+
+## Comece a partir do **GitHub template project**
+
+![package-template](./package-template.png)
+
+1. Acesse o [GitHub template project](https://github.com/napi-rs/package-template)
+2. **Clique em Usar este modelo**.
+3. Clone o seu projeto.
+4. Execute o comando `yarn install` para instalar as dependências.
+5. Execute o comando `npx napi rename` na pasta do projeto para renomear o seu pacote.

--- a/pages/docs/introduction/simple-package.pt-BR.mdx
+++ b/pages/docs/introduction/simple-package.pt-BR.mdx
@@ -1,0 +1,301 @@
+---
+title: 'Um pacote simples'
+description: Construir e publicar um pacote simples com NAPI-RS.
+---
+
+# Um pacote simples
+
+## Criando o `@napi-rs/cool`
+
+Vamos começar pelo `@napi-rs/cli`.
+
+Crie um novo projeto com `napi new`:
+
+```bash {2}
+napi new
+? Package name: (The name field in your package.json)
+```
+
+Vamos dar ao pacote um nome maneiro **@napi-rs/cool**:
+
+import { Callout } from 'nextra-theme-docs'
+
+<Callout type="warning" emoji="⚠️">
+  É recomendado usar um escopo npm para nomear seu pacote. Isso porque
+  `@napi-rs/cli` irá criar e publicar muitos pacotes por plataforma para você.
+  Se esses pacotes não estiverem sob um escopo npm, isso pode acionar a
+  [**_detecção de spam_**](https://stackoverflow.com/a/54135900/5684750) do npm
+  enquanto você os publica pela primeira vez.
+</Callout>
+
+```bash {3}
+napi new
+? Package name: (The name field in your package.json) @napi-rs/cool
+? Dir name: (cool)
+```
+
+O próximo passo é escolher o nome do diretório para o seu pacote maneiro, o valor padrão é o sufixo do nome do seu pacote. Vamos apenas pressionar **enter** e usar o valor padrão.
+
+```bash {4}
+napi new
+? Package name: (The name field in your package.json) @napi-rs/cool
+? Dir name: cool
+? Choose targets you want to support (Press <space> to select, <a> to toggle all, <i> to invert selection,
+and <enter> to proceed)
+❯ ◯ aarch64-apple-darwin
+  ◯ aarch64-linux-android
+  ◯ aarch64-unknown-linux-gnu
+  ◯ aarch64-unknown-linux-musl
+  ◯ aarch64-pc-windows-msvc
+  ◯ armv7-unknown-linux-gnueabihf
+  ◉ x86_64-apple-darwin
+(Move up and down to reveal more choices)
+```
+
+O próximo passo é escolher em quais plataformas você deseja dar suporte. Eu quero todas elas, então pressione **A** para escolher todos os alvos e pressione **enter**.
+
+```bash {8}
+napi new
+? Package name: (The name field in your package.json) @napi-rs/cool
+? Dir name: cool
+? Choose targets you want to support aarch64-apple-darwin, aarch64-linux-android, aarch64-unknown-linux-gnu
+, aarch64-unknown-linux-musl, aarch64-pc-windows-msvc, armv7-unknown-linux-gnueabihf, x86_64-apple-darwin,
+x86_64-pc-windows-msvc, x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, x86_64-unknown-freebsd, i686-p
+c-windows-msvc, armv7-linux-androideabi
+? Enable github actions? (Y/n)
+```
+
+O próximo passo é escolher se deseja habilitar a configuração do `GitHub CI`. Se o seu projeto estiver hospedado no `GitHub`, então você precisa habilitá-lo. Vamos digitar **Y** e pressionar **enter** aqui:
+
+```bash {9-16}
+napi new
+? Package name: (The name field in your package.json) @napi-rs/cool
+? Dir name: cool
+? Choose targets you want to support aarch64-apple-darwin, aarch64-linux-android, aarch64-unknown-linux-gnu
+, aarch64-unknown-linux-musl, aarch64-pc-windows-msvc, armv7-unknown-linux-gnueabihf, x86_64-apple-darwin,
+x86_64-pc-windows-msvc, x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl, x86_64-unknown-freebsd, i686-p
+c-windows-msvc, armv7-linux-androideabi
+? Enable github actions? Yes
+Writing Cargo.toml
+Writing .npmignore
+Writing build.rs
+Writing package.json
+Writing src/lib.rs
+Writing .github/workflows/CI.yml
+Writing .cargo/config.toml
+Writing rustfmt.toml
+```
+
+E agora, o `@napi-rs/cli` criou um novo pacote chamado `@napi-rs/cool` dentro do diretório `cool`.
+
+Vamos entrar nele e fazer algumas preparações:
+
+```bash
+cd cool
+yarn install
+```
+
+Estou usando `yarn` para instalar as dependências, você pode substituí-lo pelo seu gerenciador de pacote favorito.
+
+Agora, a estrutura do diretório está assim:
+
+```
+tree -a
+.
+├── .cargo
+│   └── config.toml
+├── .github
+│   └── workflows
+│       └── CI.yml
+├── .npmignore
+├── Cargo.toml
+├── build.rs
+├── npm
+├── package.json
+├── rustfmt.toml
+└── src
+    └── lib.rs
+```
+
+Seus códigos nativos estão em `src/lib.rs`. O arquivo `.cargo/config.toml` é usado no `GitHub CI` para compilação cruzada. Em geral, este arquivo não afeta seu desenvolvimento em sua máquina local.
+O arquivo `.github/workflows/CI.yml` é o arquivo de configuração para [`GitHub Actions`](https://docs.github.com/en/actions).
+O arquivo `build.rs` é necessário para construir um complemento(Addon) nativo para o `Node.js`. Não o exclua ou mova para outro lugar.
+
+Depois que a instalação do `yarn` terminar, você pode executar o comando `build` para construir seu primeiro pacote nativo:
+
+```bash
+yarn build
+yarn run v1.22.17
+$ napi build --platform --release
+    Updating crates.io index
+  Downloaded proc-macro2 v1.0.34
+  Downloaded once_cell v1.9.0
+  Downloaded napi v2.0.0-beta.7
+  Downloaded 3 crates (129.4 KB) in 2.35s
+   Compiling proc-macro2 v1.0.34
+   Compiling unicode-xid v0.2.2
+   Compiling memchr v2.4.1
+   Compiling syn v1.0.82
+   Compiling regex-syntax v0.6.25
+   Compiling convert_case v0.4.0
+   Compiling once_cell v1.9.0
+   Compiling napi-build v1.2.0
+   Compiling napi-sys v2.1.0
+   Compiling napi-rs_cool v0.0.0 (/cool)
+   Compiling quote v1.0.10
+   Compiling aho-corasick v0.7.18
+   Compiling regex v1.5.4
+   Compiling napi-derive-backend v1.0.17
+   Compiling ctor v0.1.21
+   Compiling napi-derive v2.0.0-beta.5
+   Compiling napi v2.0.0-beta.7
+    Finished release [optimized] target(s) in 37.11s
+✨  Done in 37.80s.
+```
+
+E agora a estrutura de pastas está assim:
+
+```bash {11-13}
+tree -a -I target
+.
+├── .cargo
+│   └── config.toml
+├── .github
+│   └── workflows
+│       └── CI.yml
+├── .npmignore
+├── Cargo.toml
+├── build.rs
+├── cool.darwin-x64.node
+├── index.d.ts
+├── index.js
+├── node_modules
+├── npm
+├── package.json
+├── rustfmt.toml
+└── src
+    └── lib.rs
+```
+
+Aqui estão mais três arquivos que o comando `yarn build` gerou para você.
+
+`cool.darwin-x64.node` é o arquivo binário do complemento(Addon) do Node.js, o `index.js` é o arquivo de ligação JavaScript gerado que ajuda a exportar todas as coisas no complemento para o chamador do pacote. E o `index.d.ts` é o arquivo de definição TypeScript gerado.
+
+O comando `new` gerou uma simples função `sum` para você no `src/lib.rs`:
+
+```rust {7} filename="lib.rs"
+#![deny(clippy::all)]
+
+#[macro_use]
+extern crate napi_derive;
+
+#[napi]
+fn sum(a: i32, b: i32) -> i32 {
+  a + b
+}
+```
+
+E você pode inspecionar o arquivo `index.d.ts` e ver a função `sum` que foi gerada para você:
+
+```ts {9} filename="index.d.ts"
+/* eslint-disable */
+
+export class ExternalObject<T> {
+  readonly '': {
+    readonly '': unique symbol
+    [K: symbol]: T
+  }
+}
+export function sum(a: number, b: number): number
+```
+
+Vamos criar um arquivo `test.mjs` para testar a função `sum` gerada:
+
+```js filename="test.mjs"
+import { sum } from './index.js'
+
+console.log('From native', sum(40, 2))
+```
+
+Execute isso!
+
+```bash
+node test.mjs
+From native 42
+```
+
+Parabéns! Você criou com sucesso um complemento nativo para o `Node.js`!
+
+## Publique-o!
+
+Infelizmente, você não pode publicar o `@napi-rs/cool`, porque você não tem permissão para publicar pacotes no escopo npm `@napi-rs`.
+
+No entanto, você pode criar seu próprio `escopo npm`: https://docs.npmjs.com/creating-and-publishing-scoped-public-packages.
+
+Assim que você tiver criado seu próprio escopo npm, você pode usar o comando `napi rename` para renomear o projeto recém criado.
+
+```bash {1}
+napi rename
+? name: name field in package.json
+```
+
+Vamos supor que você acabou de criar um escopo npm chamado `jarvis`, você pode digitar `@jarvis/cool` aqui:
+
+```bash {3}
+napi rename
+? name: name field in package.json @jarvis/cool
+? napi name: (cool)
+```
+
+Você não precisa alterar o campo `napi name` no `package.json` porque o sufixo do pacote não é alterado. Apenas pressione **Enter** para manter o nome `cool`.
+
+```bash
+napi rename
+? name: name field in package.json @jarvis/cool
+? napi name: cool
+? repository: Leave empty to skip
+```
+
+E você precisa de um repositório do `GitHub` se quiser publicar um pacote **NAPI-RS**, porque você precisa das `GitHub Actions` para realizar os trabalhos de compilação para você. Basta digitar a URL do seu repositório do GitHub aqui.
+
+```bash {5}
+napi rename
+? name: name field in package.json @jarvis/cool
+? napi name: cool
+? repository: Leave empty to skip
+? description: Leave empty to skip
+```
+
+E o campo `description` no arquivo `package.json`. Deixe-o vazio para pular.
+
+Agora que o nome do seu pacote foi renomeado para `@jarvis/cool`, você finalmente pode publicá-lo.
+
+Então inicie a configuração do `git` e faça o push para o GitHub.
+
+```bash
+git init
+git remote add origin git@github.com/yourname/cool.git
+git add .
+git commit -m "Init"
+git push
+```
+
+<Callout type="warning" emoji="⚠️">
+Para publicar pacotes no `GitHub Actions`, você precisa configurar a variável de ambiente `NPM_TOKEN` no seu repositório do `GitHub`.
+
+No projeto vá em **Settings -> Secrets**, e adicione seu **_NPM_TOKEN_** nele.
+
+</Callout>
+
+Se tudo funcionar corretamente, você verá a seguinte matriz de CI:
+
+![](./CI.png)
+
+Esta é apenas uma matriz de CI de teste, vamos finalmente publicar este pacote:
+
+```bash
+npm version patch
+git push --follow-tags
+```
+
+E a matriz `CI` irá construir e publicar o seu pacote `@jarvis/cool`.

--- a/pages/docs/more/_meta.pt-BR.json
+++ b/pages/docs/more/_meta.pt-BR.json
@@ -1,0 +1,4 @@
+{
+  "faq": "Perguntas Frequentes",
+  "neon": "Compare com neon"
+}

--- a/pages/docs/more/faq.pt-BR.mdx
+++ b/pages/docs/more/faq.pt-BR.mdx
@@ -1,0 +1,32 @@
+---
+description: Frequently asked questions about napi-rs.
+---
+
+# Perguntas Frequentes
+
+## Compilar para `Linux alpine`
+
+> https://github.com/rust-lang/rust/pull/40113#issuecomment-323193341
+
+Você não pode definir o `crate-type` de compilação para `cdylib` ao compilar para o destino `*-unknown-linux-musl` por padrão.
+
+Se você deseja fazer isso, precisa passar `-C target-feature=-crt-static` para `rustc`.
+
+Existem duas maneiras de passar esse argumento:
+
+- Defina a variável de ambiente `RUSTFLAGS`, `RUSTFLAGS="-C target-feature=-crt-static"`
+- Defina no arquivo `.cargo/config.toml`:
+
+  ```toml
+  [target.x86_64-unknown-linux-musl]
+  crt_static = false
+  ```
+
+## Compilar para `Windows i686`
+
+Há um erro de `codegen` ao compilar para o destino `i686-windows-*`: [Rust issue 67497](https://github.com/rust-lang/rust/issues/67497).
+
+Existe uma solução alternativa para evitar esse problema:
+
+- Defina `lto` como falso, se você não tiver definido lto em seu `Cargo.toml`, o valor é falso por padrão, você pode ignorar este.
+- Defina `codegen-units` para `32` (ou maior). O valor padrão de `codegen-units` é `16` por padrão ao compilar para release, você pode definir `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=32` e `CARGO_PROFILE_RELEASE_LTO='false'` para deixar o compilador feliz ao direcionar `i686-windows-*`. Aqui está um [exemplo](https://github.com/napi-rs/package-template/blob/main/.github/workflows/CI.yaml#L90).

--- a/pages/docs/more/neon.pt-BR.mdx
+++ b/pages/docs/more/neon.pt-BR.mdx
@@ -1,0 +1,20 @@
+---
+description: What's the difference between napi-rs and neon.
+---
+
+# Comparação com neon
+
+[neon](https://neon-bindings.com/) é outra crate Rust que oferece uma ótima experiência de desenvolvimento e alto desempenho.
+
+`neon` possui um backend v8 e um backend napi incompleto. Considerando apenas o backend N-API, também existem muitas diferenças entre `napi-rs` e `neon`.
+
+## Nível de abstração
+
+`neon` possui 2 backends e tenta abstrair sobre as 2 APIs diferentes.
+`napi-rs` é mais leve e a API está mais próxima do conceito original do N-API.
+
+## Ferramentas
+
+`neon` possui uma ferramenta cli simples que pode ajudá-lo a construir/criar pacotes localmente.
+
+`@napi-rs/cli` faz mais coisas, como gerenciar seu ambiente de compilação cruzada local e CI, ajudando-o a publicar pacotes no **GitHub Actions** sem dor de cabeça.

--- a/pages/index.pt-BR.mdx
+++ b/pages/index.pt-BR.mdx
@@ -1,0 +1,99 @@
+---
+title: 'Início'
+description: 'NAPI-RS é um framework para criar addons para Node.js em Rust.'
+---
+
+import { Badges } from '../components/badges'
+import { Rust } from '../components/chalk'
+import { Ecosystem } from '../components/ecosystem'
+import { Sponsors } from '../components/sponsors'
+import { TitlePTBR } from '../components/title.pt-BR'
+
+export const getStaticProps = async () => {
+  const sponsorsSVG = await fetch(`https://sponsors.napi.rs/sponsors.svg`).then(
+    (res) => res.text(),
+  )
+  return {
+    props: {
+      ssg: sponsorsSVG,
+    },
+  }
+}
+
+<TitlePTBR />
+
+<Badges />
+
+## Rustifique o Node.js em poucas linhas!
+
+```rust filename="lib.rs"
+use napi_derive::napi;
+
+#[napi]
+fn fibonacci(n: u32) -> u32 {
+  match n {
+    1 | 2 => 1,
+    _ => fibonacci(n - 1) + fibonacci(n - 2),
+  }
+}
+```
+
+Compatível tanto com `CommonJS` quanto com `esm`, além do arquivo `.d.ts` ser gerado automaticamente:
+
+```js filename="main.mjs"
+import { fibonacci } from './index.js'
+
+// output: 5
+console.log(fibonacci(5))
+```
+
+```js filename="main.cjs"
+const { fibonacci } = require('./index')
+
+// output: 5
+console.log(fibonacci(5))
+```
+
+## Recursos
+
+🚀 Traga desempenho nativo para o `Node.js`
+
+👷‍♂️ Segurança de memória, garantida pelo compilador do `Rust`
+
+⚡️ Transferência interativa de dados sem cópia entre `Rust` e `Node.js` via `Buffer` e `TypedArray`
+
+⚙️ Paralelismo em poucas linhas
+
+## Patrocinadores
+
+<Sponsors />
+
+## Ecossistema
+
+<Ecosystem />
+
+## Matriz de suporte
+
+### Node.js
+
+| Node10 | Node12 | Node14 | Node16 | Node18 | Node20 |
+| ------ | ------ | ------ | ------ | ------ | ------ |
+| ✓      | ✓      | ✓      | ✓      | ✓      | ✓      |
+
+### Plataformas suportadas
+
+> ✅ Significa testado oficialmente no repositório napi-rs. <br/> `-` Significa nenhuma release oficial do Node.js.
+
+|            | i686 | x64 | aarch64 | arm |
+| ---------- | ---- | --- | ------- | --- |
+| Windows    | ✅   | ✅  | ✅      | -   |
+| macOS      | -    | ✅  | ✅      | ✅  |
+| Linux      | -    | ✅  | ✅      | ✅  |
+| Linux musl | -    | ✅  | ✅      | -   |
+| FreeBSD    | -    | ✅  | -       | -   |
+| Android    | -    | -   | ✅      | ✅  |
+
+## Projetos relacionados
+
+- [neon](https://www.neon-bindings.com)
+- [node-bindgen](https://github.com/infinyon/node-bindgen)


### PR DESCRIPTION
Hello, there!

This PR adds Brazilian Portuguese language support to the documentation, enhancing accessibility for Portuguese speakers. It includes translations for all sections and contents of the documentation, including:

- [X] Homepage
- [X] Introduction
- [X] Concepts
- [X] Compat mode
- [X] CLI
- [X] Deep dive
- [X] Cross build
- [X] Ecosystem
- [X] More

I've made commits for each translated file to granularly track changes, due to my less experienced developer background. Would it be beneficial to squash these commits?

I hope this contribution help. Please review and provide feedback. Thank you!