### PR TITLE
Fix documentation for unknown-linux-musl compilation

### DIFF
--- a/pages/docs/more/faq.en.mdx
+++ b/pages/docs/more/faq.en.mdx
@@ -19,7 +19,7 @@ There are two ways to pass this argument:
 
   ```toml
   [target.x86_64-unknown-linux-musl]
-  crt_static = false
+  rustflags = ["-C", "target-feature=-crt-static"]
   ```
 
 ## Build for `Windows i686`


### PR DESCRIPTION
Setting `crt_static = false` no longer works.

Would be nice if these flags were added automatically though