### PR TITLE
fix: transform image demo crash by pinning @emnapi to 1.8.1

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,23 @@ const nextConfig = withNextra({
     locales: ['en', 'cn', 'pt-BR'],
   },
   transpilePackages: ['gsap', '@waaark/luge'],
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
+          { key: 'Cross-Origin-Embedder-Policy', value: 'require-corp' },
+        ],
+      },
+      {
+        source: '/_next/static/:path*',
+        headers: [
+          { key: 'Cross-Origin-Resource-Policy', value: 'same-origin' },
+        ],
+      },
+    ]
+  },
   webpack(config, { dev, isServer }) {
     if (!dev && !isServer) {
       const plugin = new PerfseePlugin({

--- a/package.json
+++ b/package.json
@@ -84,6 +84,8 @@
   "resolutions": {
     "@headlessui/react": "2.2.10",
     "next-mdx-remote": "6.0.0",
-    "@mdx-js/react": "^3.0.0"
+    "@mdx-js/react": "^3.0.0",
+    "@emnapi/core": "1.8.1",
+    "@emnapi/runtime": "1.8.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -433,26 +433,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/core@npm:^1.8.1":
-  version: 1.10.0
-  resolution: "@emnapi/core@npm:1.10.0"
+"@emnapi/core@npm:1.8.1":
+  version: 1.8.1
+  resolution: "@emnapi/core@npm:1.8.1"
   dependencies:
-    "@emnapi/wasi-threads": "npm:1.2.1"
+    "@emnapi/wasi-threads": "npm:1.1.0"
     tslib: "npm:^2.4.0"
-  checksum: 10c0/f51d08227857b60632de7714d708124f0e100a1462dde6df8221760939aa3204a73193830371830fac0716f3ccd2129f2cac1b17cd7d7958bc4da9018a296edb
+  checksum: 10c0/2c242f4b49779bac403e1cbcc98edacdb1c8ad36562408ba9a20663824669e930bc8493be46a2522d9dc946b8d96cd7073970bae914928c7671b5221c85b432e
   languageName: node
   linkType: hard
 
-"@emnapi/runtime@npm:^1.7.0, @emnapi/runtime@npm:^1.8.1":
-  version: 1.10.0
-  resolution: "@emnapi/runtime@npm:1.10.0"
+"@emnapi/runtime@npm:1.8.1":
+  version: 1.8.1
+  resolution: "@emnapi/runtime@npm:1.8.1"
   dependencies:
     tslib: "npm:^2.4.0"
-  checksum: 10c0/953f14991d1aefb92ee6f8eb27dea725e484791a53a0cb5f47d9e0087b9a2c929ff2e92adf95af15d6ad456db6300c6b761ebf72b50a875b874a83520b3ba093
+  checksum: 10c0/f4929d75e37aafb24da77d2f58816761fe3f826aad2e37fa6d4421dac9060cbd5098eea1ac3c9ecc4526b89deb58153852fa432f87021dc57863f2ff726d713f
   languageName: node
   linkType: hard
 
-"@emnapi/wasi-threads@npm:1.2.1, @emnapi/wasi-threads@npm:^1.1.0":
+"@emnapi/wasi-threads@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@emnapi/wasi-threads@npm:1.1.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/e6d54bf2b1e64cdd83d2916411e44e579b6ae35d5def0dea61a3c452d9921373044dff32a8b8473ae60c80692bdc39323e98b96a3f3d87ba6886b24dd0ef7ca1
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:^1.1.0":
   version: 1.2.1
   resolution: "@emnapi/wasi-threads@npm:1.2.1"
   dependencies:


### PR DESCRIPTION
## Summary

Fixes the homepage's "Transform Image App" demo, which throws `TypeError: Cannot read properties of undefined (reading 'whenLoaded')` in Chrome on click.

Refs napi-rs/napi-rs#3262

## Root cause

`@napi-rs/image-wasm32-wasi`'s prebuilt `.wasm` is linked against emnapi 1.8.x, which uses an internal worker-pool to track threads. But `@napi-rs/wasm-runtime` resolves `@emnapi/core` to `^1.7.1`, which in practice installs 1.10.0 — and from 1.9.0 onward, emnapi switched to delegating to `pthread_create` and stopped maintaining a separate pool. The JS runtime then reads a `tid` from a memory location the prebuilt wasm never populates, so `PThread.pthreads[tid]` is `undefined` when `initWorkers` tries to read `.whenLoaded` on it.

This is the same mismatch reported and explained in [toyobayashi/emnapi#202](https://github.com/toyobayashi/emnapi/issues/202).

## Changes

- **`package.json`**: pin `@emnapi/core` and `@emnapi/runtime` to `1.8.1` via `resolutions` so the JS runtime matches what the prebuilt `.wasm` was linked against.
- **`next.config.js`**: add COOP/COEP at the document level and `Cross-Origin-Resource-Policy: same-origin` on `/_next/static/*`. `middleware.js` already set COOP/COEP on HTML, but Next.js middleware doesn't run on `/_next/static/*`, so static worker chunks lacked CORP — required under `Cross-Origin-Embedder-Policy: require-corp` for `SharedArrayBuffer`-backed wasm threading.

## Test plan

- [x] `yarn dev` → open homepage → click **Transform image to webp** → completes successfully (previously threw)
- [x] DevTools console: `crossOriginIsolated === true`
- [x] All 5 `image.wasm32-wasi.*.wasm` requests return 200