### PR TITLE
fix(link-preview): match napi.rs card spacing

### DIFF
--- a/components/link-preview.tsx
+++ b/components/link-preview.tsx
@@ -80,24 +80,22 @@ export function LinkPreview({ href, data }: { href: string; data?: string }) {
     />
   )
   return (
+    // The below-card separation gap lives on this wrapper's OWN margin, not on
+    // the Card's marginBottom. The wrapper carries the onClick + cursor-pointer,
+    // and a flex item's margin sits INSIDE the wrapper's box — so a gap placed
+    // there becomes part of the click target (clicking the whitespace below the
+    // card opens the link). A margin on the wrapper is outside its hit area:
+    // separation without a dead-click strip. Matches napi.rs's ~24px gap below.
     <div
       className="flex justify-center w-full cursor-pointer"
+      style={{ marginBottom: '24px' }}
       onClick={() => {
         window.open(href, '_blank')
       }}
     >
       <Card
         className="w-full gap-2 py-3 backdrop-blur"
-        style={{
-          border: 'solid 1px oklch(0.922 0 0)',
-          marginTop: '10px',
-          // The card is an island embedded in @void/md prose, whose `p {
-          // margin-bottom }` rhythm gives the following block no top margin (see
-          // the inner `my-0` resets below). Add the gap below the card here so
-          // it isn't jammed against the next paragraph — matching napi.rs's
-          // ~24px separation.
-          marginBottom: '24px',
-        }}
+        style={{ border: 'solid 1px oklch(0.922 0 0)', marginTop: '10px' }}
       >
         <CardHeader>
           <CardTitle className="text-shadow-lg">

--- a/components/link-preview.tsx
+++ b/components/link-preview.tsx
@@ -88,7 +88,16 @@ export function LinkPreview({ href, data }: { href: string; data?: string }) {
     >
       <Card
         className="w-full gap-2 py-3 backdrop-blur"
-        style={{ border: 'solid 1px oklch(0.922 0 0)', marginTop: '10px' }}
+        style={{
+          border: 'solid 1px oklch(0.922 0 0)',
+          marginTop: '10px',
+          // The card is an island embedded in @void/md prose, whose `p {
+          // margin-bottom }` rhythm gives the following block no top margin (see
+          // the inner `my-0` resets below). Add the gap below the card here so
+          // it isn't jammed against the next paragraph — matching napi.rs's
+          // ~24px separation.
+          marginBottom: '24px',
+        }}
       >
         <CardHeader>
           <CardTitle className="text-shadow-lg">
@@ -112,10 +121,19 @@ export function LinkPreview({ href, data }: { href: string; data?: string }) {
         </CardHeader>
         <CardContent className="flex justify-between">
           <div className="flex-col justify-between w-1/2 flex">
-            <p className="link-preview-body line-clamp-4 text-sm">
+            {/* Inline `margin: 0` (NOT a `my-0` class): the card lives inside
+                @void/md prose, whose `.void-md p { margin-bottom: 14px }` rule
+                (specificity 0,1,1) outranks a `.my-0` utility (0,1,0), so the
+                class is ignored and the footer gets pushed up (measured 27px vs
+                napi.rs's 13px). An inline style wins, resetting it so the footer
+                sits tight to the card bottom. */}
+            <p
+              className="link-preview-body line-clamp-4 text-sm"
+              style={{ margin: 0 }}
+            >
               {linkMeta.body}
             </p>
-            <p className="flex text-sm align-center">
+            <p className="flex text-sm align-center" style={{ margin: 0 }}>
               <span className="inline-block align-middle">{logo}</span>
               <span
                 style={{


### PR DESCRIPTION
## What

The GitHub link-preview card (e.g. on `/blog/announce-v3`) had visibly different inner/outer spacing than napi.rs.

Root cause: the card is an island embedded in `@void/md` prose, whose `.void-md p { margin-bottom: 1em }` rule leaks into the card's own inner `<p>` elements (body + footer). At the card's `text-sm` (14px) size that:
- pushed the **footer up** — 27px above the card bottom vs napi.rs's 13px, and
- gave the block after the island **no top margin**, jamming the next paragraph against the card (0px vs napi.rs's 24px).

## Fix (scoped to the card, `components/link-preview.tsx`)

- Reset the inner `<p>` margins with **inline `margin: 0`** — a `my-0` utility (specificity 0,1,0) loses to `.void-md p` (0,1,1), but inline style wins.
- Add `marginBottom: 24px` on the `Card` for the below-card separation.

## Verified

Measured in a local preview build (footer/below-card gaps, viewport parity with napi.rs):

| metric | napi.rs | before | after |
|---|---|---|---|
| footer → card-bottom gap | 13px | 27px | **13px** ✅ |
| gap below card | 24px | 0px | **24px** ✅ |
| inner `<p>` margin | 0 | 14px | **0** ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)