### PR TITLE
fix(sponsors): hide web-infra-dev (no longer sponsors napi-rs)

### DIFF
--- a/lib/landing/load-sponsors.ts
+++ b/lib/landing/load-sponsors.ts
@@ -23,9 +23,16 @@ const ORG_LOGIN = 'napi-rs'
 // sponsors.svg generator) — VoidZero is not a GitHub sponsor tier.
 const SPECIAL_THANKS_LOGIN = 'voidzero-dev'
 
-// Never shown in the auto tiers: ArrayZoneYour (upstream-excluded) and
-// voidzero-dev (rendered under Special Thanks, so it must not also double-up).
-const EXCLUDED_LOGINS = new Set([SPECIAL_THANKS_LOGIN, 'ArrayZoneYour'])
+// Logins force-hidden from the auto tiers:
+//   - voidzero-dev  -> rendered under Special Thanks, must not also double-up
+//   - ArrayZoneYour -> upstream-excluded
+//   - web-infra-dev -> no longer sponsors the project; a past sponsorship still
+//                      surfaces via the live Sponsors API, so hide it explicitly
+const EXCLUDED_LOGINS = new Set([
+  SPECIAL_THANKS_LOGIN,
+  'ArrayZoneYour',
+  'web-infra-dev',
+])
 
 // Tier thresholds (monthly USD), matching the upstream sponsors.svg generator:
 //   platinum >= 1000 | gold >= 200 | sliver >= 10 (recurring only) | backers = rest

--- a/lib/landing/sponsors.test.ts
+++ b/lib/landing/sponsors.test.ts
@@ -14,8 +14,8 @@ const raw = {
   ],
   platinum: [
     {
-      login: 'web-infra-dev',
-      name: 'Web Infra',
+      login: 'github',
+      name: 'GitHub',
       avatarUrl: 'data:image/png;2',
     },
   ],


### PR DESCRIPTION
## What

Web Infra (`web-infra-dev`) no longer sponsors napi-rs, but a past sponsorship still surfaces via GitHub's **live** Sponsors API, so it kept appearing on the landing sponsor wall. Force-hide it.

```
bucket():  if (EXCLUDED_LOGINS.has(entity.login)) continue
                         ↑
   { voidzero-dev, ArrayZoneYour, +web-infra-dev }
```

Same lever already used for `ArrayZoneYour` — one entry added to `EXCLUDED_LOGINS`. If GitHub ever stops returning them, the exclusion is a harmless no-op.

## Changes

- `lib/landing/load-sponsors.ts` — add `web-infra-dev` to `EXCLUDED_LOGINS` (+ document why).
- `lib/landing/sponsors.test.ts` — swap the now-misleading `web-infra-dev` **wash** fixture to a neutral `github` placeholder. `wash()` never sees excluded logins (exclusion runs earlier, in `bucket()`), so this is cosmetic only; asserted values are unchanged.

## Verification

- `lib/landing` vitest: 6/6 pass
- `vp fmt --check`: clean

> Follow-up to #472 (which merged first). Rebased onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)