### PR TITLE
fix(footer): give landing language switcher its own divided top zone

### DIFF
--- a/components/docs/Footer.tsx
+++ b/components/docs/Footer.tsx
@@ -35,33 +35,44 @@ export default function Footer({ locale, className }: FooterProps) {
   return (
     <div
       className={cn(
-        'mx-auto flex w-full max-w-[1400px] flex-col gap-6 px-6 py-10 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between',
+        'mx-auto w-full max-w-[1400px] px-6 py-10 text-sm text-muted-foreground',
         className,
       )}
     >
-      <div className="flex flex-col gap-2">
-        {locale ? (
-          <div className="mb-1 flex items-center gap-1">
-            {/* -ml-2.5 cancels the labeled button's left padding (size=sm +
-                has-[>svg] -> px-2.5) so the globe icon sits flush-left, aligned
-                with the Logo + license text stacked below it. */}
-            <LangSwitcher locale={locale} showLabel className="-ml-2.5" />
-          </div>
-        ) : null}
-        <Logo />
-        <p>Released under the MIT License.</p>
-        <p>Copyright © {year} NAPI-RS.</p>
-      </div>
+      {/* Landing only: the language switcher is its OWN top control zone with a
+          divider, matching live napi.rs (which sits the locale/theme controls in
+          a bordered top row, well clear of the brand block below). Stacking it
+          tight above the logo made the small globe's label ("English") sit
+          visibly out of line with the larger logo's wordmark ("NAPI-RS") — a
+          16px stagger, since the globe is 16px and the logo 32px at the same
+          icon->label gap. A dedicated, divided zone removes that entirely.
+          Docs pass no locale and skip this (their switcher lives in the sidebar
+          chrome), so the divider only ever renders in the dark landing footer. */}
+      {locale ? (
+        <div className="mb-8 border-b border-border pb-6">
+          {/* -ml-2.5 cancels the labeled button's left padding (size=sm +
+              has-[>svg] -> px-2.5) so the globe sits flush-left with the Logo. */}
+          <LangSwitcher locale={locale} showLabel className="-ml-2.5" />
+        </div>
+      ) : null}
 
-      <div className="flex flex-col gap-2 sm:items-end">
-        <a
-          href="https://void.cloud"
-          target="_blank"
-          rel="noreferrer noopener"
-          className="transition-colors hover:text-primary"
-        >
-          Built with Void
-        </a>
+      <div className="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-2">
+          <Logo />
+          <p>Released under the MIT License.</p>
+          <p>Copyright © {year} NAPI-RS.</p>
+        </div>
+
+        <div className="flex flex-col gap-2 sm:items-end">
+          <a
+            href="https://void.cloud"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="transition-colors hover:text-primary"
+          >
+            Built with Void
+          </a>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## What

On the **landing** footer, the language switcher was stacked tight above the logo, so "English" and "NAPI-RS" didn't line up:

```
BEFORE                          AFTER (matches live napi.rs)
🌐 English        ← x=48        🌐 English          ← own zone
[LOGO] NAPI-RS    ← x=64        ──────────────────  ← divider
Released under…                 [LOGO] NAPI-RS       Built with Void
Copyright…                      Released under the MIT License.
                                Copyright © 2026 NAPI-RS.
```

## Root cause (measured, not guessed)

The left rail was already fine — globe, logo, and both legal lines all sit at x=24 (pixel-verified: every glyph within 0.5px of the box edge). The real issue: the **labels** stagger by 16px. The globe is 16px and the logo is 32px, both with the same 8px icon→label gap, so "English" lands at x=48 and "NAPI-RS" at x=64.

## Fix

Live napi.rs sidesteps this by putting the locale/theme controls in a **bordered top row**, well clear of the brand block. This mirrors that: the switcher moves into its own top zone with a `border-b` divider and a 32px gap to the logo. The stagger stops reading as misalignment because the control no longer sits directly on top of the wordmark.

- `components/docs/Footer.tsx` — restructure the landing footer (locale present) into `[control zone + divider]` over `[brand row]`. No new deps, no logic change.

## Scope / verification (Playwright against the dev server)

- **Landing** (`/`): switcher in a divided top zone; logo/license/copyright at x=24; "Built with Void" right-aligned to the brand row.
- **Docs** (`/docs/cross-build`): passes no locale → **no** top zone, **no** divider, switcher absent (it lives in the sidebar there). logo/license at x=24 — unchanged.
- `vp fmt --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)