### PR TITLE
fix(seo): give the breadcrumb group crumb an `item` URL

### DIFF
--- a/lib/docs/page-data.ts
+++ b/lib/docs/page-data.ts
@@ -177,6 +177,33 @@ export function firstSectionLeafHref(
 }
 
 /**
+ * The localized href of the FIRST reachable leaf of the GROUP that owns
+ * `leafPath` (in sidebar order). The group crumb renders as plain, non-link
+ * text (a docs group has no index page), but Google's BreadcrumbList still
+ * requires an `item` URL on every non-last ListItem — so the JSON-LD builder
+ * points the group crumb here, the same index-less convention the tab crumb
+ * uses via `firstSectionLeafHref`. Returns null when the group has no reachable
+ * page (never happens for a page rendered inside that group — its own leaf is a
+ * reachable member).
+ */
+export function firstGroupLeafHref(
+  leafPath: string,
+  locale: Locale,
+  localeNav: LocaleNav,
+  existsByPage: Record<Locale, ReadonlySet<string>>,
+): string | null {
+  const groups = localeNav.sidebar[leafSection(leafPath)] ?? []
+  const found = findGroupAndLeaf(groups, leafPath)
+  if (!found) return null
+  for (const item of found.group.items) {
+    if (isLeafReachable(item.path, locale, existsByPage)) {
+      return localizeHref(item.path, locale)
+    }
+  }
+  return null
+}
+
+/**
  * Whether a section has at least one reachable page in `locale`. Drives tab
  * visibility: only tabs whose section currently has migrated content show.
  */

--- a/lib/seo/jsonld.test.ts
+++ b/lib/seo/jsonld.test.ts
@@ -27,9 +27,16 @@ describe('jsonLdFor', () => {
     expect(g.some((n: any) => n['@type'] === 'TechArticle')).toBe(true)
     const bc = g.find((n: any) => n['@type'] === 'BreadcrumbList')
     expect(bc).toBeTruthy()
-    for (const li of bc.itemListElement) {
-      if (li.item) expect(li.item).toMatch(/^https:\/\/napi\.rs\//)
-    }
+    // Every non-last crumb MUST carry an absolute `item` URL — including the
+    // middle "group" crumb, which renders as plain text but still needs an
+    // `item` or Google flags "missing field item (in itemListElement)".
+    bc.itemListElement.forEach((li: any, i: number) => {
+      if (i < bc.itemListElement.length - 1) {
+        expect(li.item, `crumb ${i} "${li.name}" needs item`).toMatch(
+          /^https:\/\/napi\.rs\//,
+        )
+      }
+    })
   })
   it('blog emits BlogPosting; datePublished present only when known', () => {
     const withDate = parse(

--- a/lib/seo/jsonld.ts
+++ b/lib/seo/jsonld.ts
@@ -2,7 +2,7 @@
 import { selfCanonical, neutralPath, BASE_URL } from './urls.ts'
 import { getLocale, htmlLang } from '../docs/locale.ts'
 import { nav, type Locale } from '../nav/index.ts'
-import { getBreadcrumbCore } from '../docs/page-data.ts'
+import { getBreadcrumbCore, firstGroupLeafHref } from '../docs/page-data.ts'
 import { routeMap, blogDates } from '../i18n/route-map.gen.ts'
 
 const ORGANIZATION = {
@@ -41,16 +41,29 @@ function breadcrumbList(publicPath: string) {
   const leaf = neutralPath(publicPath).replace(/^\//, '')
   const crumbs = getBreadcrumbCore(leaf, locale, nav[locale], EXISTS_BY_PAGE)
   if (!crumbs.length) return null
+  // The middle "group" crumb renders as plain text (a docs group has no index
+  // page), so getBreadcrumbCore leaves its href empty — but Google requires an
+  // `item` on every non-last ListItem. Fall back to the group's first reachable
+  // leaf, mirroring how the tab crumb resolves its own index-less level.
+  const groupHref = firstGroupLeafHref(
+    leaf,
+    locale,
+    nav[locale],
+    EXISTS_BY_PAGE,
+  )
+  const abs = (h: string) => (h.startsWith('http') ? h : `${BASE_URL}${h}`)
   return {
     '@type': 'BreadcrumbList',
-    itemListElement: crumbs.map((c, i) => ({
-      '@type': 'ListItem',
-      position: i + 1,
-      name: c.label,
-      ...(c.href
-        ? { item: c.href.startsWith('http') ? c.href : `${BASE_URL}${c.href}` }
-        : {}),
-    })),
+    itemListElement: crumbs.map((c, i) => {
+      const isLast = i === crumbs.length - 1
+      const href = c.href || (isLast ? '' : (groupHref ?? ''))
+      return {
+        '@type': 'ListItem',
+        position: i + 1,
+        name: c.label,
+        ...(href ? { item: abs(href) } : {}),
+      }
+    }),
   }
 }
 


### PR DESCRIPTION
## Problem

Google Search Console reports **「未填写字段"item"（在"itemListElement"中）」 / "Missing field `item` (in `itemListElement`)"** on 6 docs pages' `BreadcrumbList` JSON-LD:

```
/docs/concepts/types-overwrite   /docs/concepts/external   /docs/concepts/async-fn
/docs/cli/pre-publish   /docs/introduction/simple-package   /docs/deep-dive/history
```

## Root cause

The docs breadcrumb is `Tab › Group › Leaf`. The middle **group** crumb (Concepts, CLI, …) renders as plain non-link text — a docs group has no index page — so `getBreadcrumbCore` returns it with an empty `href`, and `lib/seo/jsonld.ts` only emitted `item` when `href` was truthy:

```
pos 1  "Docs"      item=…/docs/introduction/getting-started   ✓
pos 2  "Concepts"  item=MISSING                               ✗  (non-last ⇒ Google error)
pos 3  "Types Overwrite"  item=…/docs/concepts/types-overwrite ✓
```

Google requires `item` on **every non-last** `ListItem`, so the group level was flagged on all `/docs/GROUP/leaf` pages. (The existing test had an `if (li.item)` guard that silently tolerated it.)

## Fix

Point the group crumb at the **first reachable leaf of its group** — the exact index-less convention the **tab** crumb already uses (`firstSectionLeafHref`, because `/docs` itself 404s). New sibling helper `firstGroupLeafHref`; used only by the JSON-LD builder, so the visible breadcrumb (group stays plain text) is unchanged.

After:

```
pos 2  "Concepts"    item=…/docs/concepts/exports
pos 2  "CLI"         item=…/docs/cli/programmatic-api
pos 2  "Deep dive"   item=…/docs/deep-dive/native-module
```

## Validation

- ✅ Probe over all 6 flagged URLs — **0** non-last crumbs missing `item`
- ✅ `jsonld` / `head` / `page-data` suites — 49/49 pass
- ✅ Test guard tightened to require `item` on every non-last crumb (regression lock)
- ✅ Changed files are typecheck-clean (pre-existing `hreflang.test.ts` advisory errors are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)