### PR TITLE
fix(docs): thin scrollbar for horizontally-scrolling wide tables

### DIFF
--- a/pages/theme.css
+++ b/pages/theme.css
@@ -456,3 +456,26 @@
   max-width: 100%;
   height: auto;
 }
+
+/* Thin, subtle scrollbar for horizontally-scrolling wide tables. @void/md makes
+ * `.void-md table` a `display:block; overflow-x:auto` scroll container
+ * (prose.css), which otherwise shows the browser's thick, bright system
+ * scrollbar under the table. Mirror the sidebar's `.thin-scrollbar` (style.css)
+ * so the table scrollbar matches the rest of the docs. */
+.void-md table {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(115, 115, 115, 0.4) transparent;
+}
+.void-md table::-webkit-scrollbar {
+  width: 0.75rem;
+  height: 0.75rem;
+}
+.void-md table::-webkit-scrollbar-track {
+  background-color: transparent;
+}
+.void-md table::-webkit-scrollbar-thumb {
+  background-color: rgba(115, 115, 115, 0.4);
+  border-radius: 10px;
+  border: 3px solid transparent;
+  background-clip: padding-box;
+}


### PR DESCRIPTION
## Problem

`@void/md` makes `.void-md table` a `display:block; overflow-x:auto` scroll container (prose.css). Wide tables (e.g. `napi-attributes`) showed the browser's thick, bright **default system scrollbar** under the table — harsh against the dark docs theme.

```
BEFORE:  ████████████████  ← thick, bright system scrollbar
AFTER:   ▬▬▬▬▬▬▬            ← thin, subtle gray-on-transparent (matches the sidebar)
```

## Fix

Apply the treatment the sidebar already uses (`.thin-scrollbar` in `style.css`) to `.void-md table`, added to `theme.css` (the `.void-md`-scoped, last-loaded override sheet): `scrollbar-width: thin` + gray-on-transparent `scrollbar-color`, with the `::-webkit-scrollbar` fallback for WebKit/older engines. One file, no markup changes.

## Verification

Rendered a before/after of the exact CSS cascade in headless Chromium — the table scrollbar is now the same thin, subtle thumb used across the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)