### PR TITLE
feat(support-matrix): add nodeOmit to drop EOL node majors from the card

### DIFF
--- a/components/support-matrix-builder/index.tsx
+++ b/components/support-matrix-builder/index.tsx
@@ -79,6 +79,7 @@ export default function SupportMatrixBuilder() {
   const [name, setName] = useState('')
   const [engines, setEngines] = useState('^22.20 || ^24.12 || >=25')
   const [nodeTested, setNodeTested] = useState('22, 24')
+  const [nodeOmit, setNodeOmit] = useState('')
   const [badgeTheme, setBadgeTheme] = useState<BadgeTheme>('light')
   const [copied, setCopied] = useState<string | null>(null)
 
@@ -115,10 +116,11 @@ export default function SupportMatrixBuilder() {
         name: name.trim() || undefined,
         engines: engines.trim() || undefined,
         nodeTested: parseMajors(nodeTested),
+        nodeOmit: parseMajors(nodeOmit),
         theme,
       }
     }
-  }, [targets, tiers, full, wasm, name, engines, nodeTested])
+  }, [targets, tiers, full, wasm, name, engines, nodeTested, nodeOmit])
 
   // light → no theme param (the parser's default); dark → theme=dark.
   const previewQuery = useMemo(
@@ -270,6 +272,20 @@ export default function SupportMatrixBuilder() {
             value={engines}
             onChange={(e) => setEngines(e.target.value)}
             placeholder="^22.20 || ^24.12 || >=25"
+          />
+        </div>
+
+        <div>
+          <label className={labelCls} htmlFor="sm-node-omit">
+            Omit node majors (drop a major the range permits, e.g. an EOL
+            runtime — the engines string still shows verbatim)
+          </label>
+          <input
+            id="sm-node-omit"
+            className={fieldCls}
+            value={nodeOmit}
+            onChange={(e) => setNodeOmit(e.target.value)}
+            placeholder="25"
           />
         </div>
 

--- a/lib/support-matrix/node.test.ts
+++ b/lib/support-matrix/node.test.ts
@@ -104,6 +104,62 @@ describe('deriveNode — upper bounds and hyphen ranges', () => {
   })
 })
 
+describe('deriveNode — omit majors (drop EOL runtimes the range still permits)', () => {
+  // 25 reached EOL 2026-06-01; omit it even though `>=25` permits it. The engines
+  // string is shown verbatim on the card, so nothing is concealed — the pill for
+  // an EOL runtime just goes away so the card does not steer users onto it.
+  it('drops an omitted major from the pills, keeping the rest in order', () => {
+    const model = deriveNode('^22.20 || ^24.12 || >=25', [22, 24], 26, [25])
+    expect(model.pills).toEqual([
+      { major: 22, floor: '22.20', tested: true },
+      { major: 24, floor: '24.12', tested: true },
+      { major: 26, floor: null, tested: false },
+    ])
+  })
+
+  it('an omitted major is silent — not a pill and not an excluded mention', () => {
+    const model = deriveNode('^22.20 || ^24.12 || >=25', [22, 24], 26, [25])
+    expect(model.excluded).toContain('23')
+    expect(model.excluded).not.toContain('25')
+  })
+
+  it('leaves the engines-derived headline untouched', () => {
+    const model = deriveNode('^22.20 || ^24.12 || >=25', [22, 24], 26, [25])
+    expect(model.headline).toBe('v22.20 → v26')
+  })
+
+  it('omitting nothing (arg absent) is the pre-existing behavior', () => {
+    const model = deriveNode('^22.20 || ^24.12 || >=25', [22, 24], 26)
+    expect(model.pills.map((p) => p.major)).toEqual([22, 24, 25, 26])
+  })
+
+  // Boundary cases — the headline and excluded prose must stay consistent with the
+  // pills after an omission, not dangle at a major that no longer has a pill.
+  it('omitting the ceiling major retracts the headline to the highest survivor', () => {
+    const model = deriveNode('>=22', [], 26, [26])
+    expect(model.pills.map((p) => p.major)).toEqual([22, 23, 24, 25])
+    expect(model.headline).toBe('v22 → v25')
+  })
+
+  it('omitting the floor major advances the headline to the lowest survivor', () => {
+    const model = deriveNode('^22.20 || ^24.12 || >=25', [22, 24], 26, [22])
+    expect(model.pills.map((p) => p.major)).toEqual([24, 25, 26])
+    expect(model.headline).toBe('v24.12 → v26')
+  })
+
+  it('omitting an already-excluded major silences its excluded mention', () => {
+    const model = deriveNode('^22.20 || ^24.12 || >=25', [], 26, [23])
+    expect(model.excluded).not.toContain('23')
+    expect(model.excluded).toContain('24.0')
+  })
+
+  it('omitting every covered major yields no pills and a floor-only headline', () => {
+    const model = deriveNode('^22.20', [], 26, [22])
+    expect(model.pills).toEqual([])
+    expect(model.headline).toBe('v22.20')
+  })
+})
+
 describe('deriveNode — never throws on garbage', () => {
   it('returns a well-formed (empty) model for unparseable input', () => {
     const model = deriveNode('not a range', [], 26)

--- a/lib/support-matrix/node.test.ts
+++ b/lib/support-matrix/node.test.ts
@@ -158,6 +158,23 @@ describe('deriveNode — omit majors (drop EOL runtimes the range still permits)
     expect(model.pills).toEqual([])
     expect(model.headline).toBe('v22.20')
   })
+
+  it('omitting an endpoint major shrinks the excluded span, not just the headline', () => {
+    // ^22 || ^26 with 26 omitted advertises only v22, so 23/24/25 sit BEYOND the
+    // surviving span — they must not be reported as excluded.
+    const model = deriveNode('^22 || ^26', [], 26, [26])
+    expect(model.pills.map((p) => p.major)).toEqual([22])
+    expect(model.headline).toBe('v22')
+    expect(model.excluded).toBeNull()
+  })
+
+  it('lists gaps only between surviving pills', () => {
+    // ^22 || ^24 || ^26, omit 26 → survivors 22 and 24; 23 is between them (kept),
+    // 25 is beyond the last survivor (dropped).
+    const model = deriveNode('^22 || ^24 || ^26', [], 26, [26])
+    expect(model.pills.map((p) => p.major)).toEqual([22, 24])
+    expect(model.excluded).toBe('23')
+  })
 })
 
 describe('deriveNode — never throws on garbage', () => {

--- a/lib/support-matrix/node.ts
+++ b/lib/support-matrix/node.ts
@@ -170,10 +170,15 @@ export function deriveNode(
   engines: string,
   nodeTested: number[],
   latest: number,
+  // Majors to drop from the pills entirely — an EOL runtime the range still
+  // permits (`>=25` admits 25 after its EOL). The engines string is rendered
+  // verbatim, so this hides only the pill, not the contract.
+  nodeOmit: number[] = [],
 ): NodeModel {
   const enginesRaw = (engines ?? '').trim()
   const parts = parseRange(enginesRaw, latest)
   const tested = new Set((nodeTested ?? []).filter((n) => Number.isInteger(n)))
+  const omit = new Set((nodeOmit ?? []).filter((n) => Number.isInteger(n)))
 
   if (parts.length === 0) {
     return { headline: `v${latest}`, enginesRaw, excluded: null, pills: [] }
@@ -183,11 +188,14 @@ export function deriveNode(
   const ceiling = rangeCeiling(parts, latest)
   const left =
     floor.minor > 0 ? `v${floor.major}.${floor.minor}` : `v${floor.major}`
-  const headline = floor.major < ceiling ? `${left} → v${ceiling}` : left
 
   const pills: NodePill[] = []
   const gaps: string[] = []
   for (let major = floor.major; major <= ceiling; major++) {
+    // An explicitly omitted (e.g. EOL) major is dropped whole — before any
+    // coverage/gap accounting — so it leaves no pill AND no `excluded` mention,
+    // whether or not the range covered it. It simply vanishes from the card.
+    if (omit.has(major)) continue
     const cov = coverage(parts, major)
     if (!cov.covered) {
       // Fully-excluded major — only listed above the floor major (nothing
@@ -206,6 +214,21 @@ export function deriveNode(
       tested: tested.has(major),
     })
   }
+
+  // Span the headline across the SURVIVING pills, so an omitted floor or ceiling
+  // never dangles (a `→ v26` with no v26 pill). With nothing omitted this is the
+  // plain floor→ceiling span; with every major omitted it falls back to the range
+  // floor. `enginesRaw` is rendered verbatim regardless, so the declared range is
+  // never concealed.
+  const lo = pills[0]
+  const hi = pills[pills.length - 1]
+  const headline = lo
+    ? lo.major < hi.major
+      ? `${lo.floor ? `v${lo.floor}` : `v${lo.major}`} → v${hi.major}`
+      : lo.floor
+        ? `v${lo.floor}`
+        : `v${lo.major}`
+    : left
 
   return {
     headline,

--- a/lib/support-matrix/node.ts
+++ b/lib/support-matrix/node.ts
@@ -191,6 +191,14 @@ export function deriveNode(
 
   const pills: NodePill[] = []
   const gaps: string[] = []
+  // Gaps are recorded only BETWEEN surviving pills. Uncovered majors are buffered
+  // and committed when a later pill confirms both ends of the gap; anything before
+  // the first surviving pill (below the surviving floor) or after the last (beyond
+  // the surviving ceiling) is out of scope and discarded. So omitting an endpoint
+  // major shrinks the excluded span together with the headline, instead of leaving
+  // `excluded` pointing past the last pill.
+  let sawPill = false
+  let pendingGaps: string[] = []
   for (let major = floor.major; major <= ceiling; major++) {
     // An explicitly omitted (e.g. EOL) major is dropped whole — before any
     // coverage/gap accounting — so it leaves no pill AND no `excluded` mention,
@@ -198,16 +206,24 @@ export function deriveNode(
     if (omit.has(major)) continue
     const cov = coverage(parts, major)
     if (!cov.covered) {
-      // Fully-excluded major — only listed above the floor major (nothing
-      // below the floor is ever "excluded", it is simply out of scope).
-      if (major > floor.major) gaps.push(String(major))
+      // A fully-excluded major only counts once it is bounded by a pill on both
+      // sides — buffer it and let a later pill commit it (or a trailing run be
+      // discarded).
+      if (sawPill) pendingGaps.push(String(major))
       continue
     }
-    // A major entered above `.0` leaves a `maj.0–maj.min-1` gap (again, only
-    // above the floor major — the floor major's below-floor minors are scope).
-    if (major > floor.major && cov.floorMinor > 0) {
-      gaps.push(`${major}.0–${major}.${cov.floorMinor - 1}`)
+    if (sawPill) {
+      // Buffered uncovered majors are now bounded on both sides by a pill.
+      gaps.push(...pendingGaps)
+      // This surviving major's own `maj.0–maj.min-1` gap when entered above `.0`
+      // — but never for the first surviving pill, whose below-floor minors are
+      // scope (the same reason the range floor's own below-`.0` is not listed).
+      if (cov.floorMinor > 0) {
+        gaps.push(`${major}.0–${major}.${cov.floorMinor - 1}`)
+      }
     }
+    pendingGaps = []
+    sawPill = true
     pills.push({
       major,
       floor: cov.floorMinor > 0 ? `${major}.${cov.floorMinor}` : null,

--- a/lib/support-matrix/query.test.ts
+++ b/lib/support-matrix/query.test.ts
@@ -134,6 +134,23 @@ describe('buildSupportMatrixQuery — omission + cleaning', () => {
   })
 })
 
+describe('buildSupportMatrixQuery — nodeOmit (drop EOL majors)', () => {
+  it('round-trips nodeOmit through build → parse', () => {
+    const built = buildSupportMatrixQuery({
+      engines: '^22.20 || ^24.12 || >=25',
+      nodeTested: [22, 24],
+      nodeOmit: [25],
+    })
+    expect(new URLSearchParams(built).get('nodeOmit')).toBe('25')
+    expect(reparse(built).query.nodeOmit).toEqual([25])
+  })
+
+  it('drops the param when nothing integer survives', () => {
+    const built = buildSupportMatrixQuery({ nodeOmit: [Number.NaN] })
+    expect(new URLSearchParams(built).has('nodeOmit')).toBe(false)
+  })
+})
+
 describe('buildSupportMatrixQuery — theme + dark round-trip', () => {
   it('a dark build parses back to the dark theme', () => {
     const built = buildSupportMatrixQuery({ tested: ['full'], theme: 'dark' })

--- a/lib/support-matrix/query.ts
+++ b/lib/support-matrix/query.ts
@@ -64,6 +64,9 @@ export function parseSupportMatrixQuery(
     // Raw semver range — `resolveMatrix`/`deriveNode` parse it.
     engines: get('engines'),
     nodeTested: parseNodeTested(get('nodeTested')),
+    // Node majors to drop from the pills even though `engines` permits them
+    // (an EOL runtime) — same integer-only parsing as nodeTested.
+    nodeOmit: parseNodeTested(get('nodeOmit')),
   }
   return { query, theme: parseTheme(get('theme')) }
 }
@@ -94,6 +97,8 @@ export interface SupportMatrixQueryInput {
   engines?: string
   // Node majors marked tested (deduped/filtered to finite integers).
   nodeTested?: number[]
+  // Node majors to DROP from the pills — an EOL runtime the range still permits.
+  nodeOmit?: number[]
   theme?: Theme
 }
 
@@ -133,6 +138,11 @@ export function buildSupportMatrixQuery(
   if (input.nodeTested && input.nodeTested.length) {
     const majors = input.nodeTested.filter((n) => Number.isInteger(n))
     if (majors.length) params.append('nodeTested', majors.join(','))
+  }
+
+  if (input.nodeOmit && input.nodeOmit.length) {
+    const majors = input.nodeOmit.filter((n) => Number.isInteger(n))
+    if (majors.length) params.append('nodeOmit', majors.join(','))
   }
 
   const name = input.name?.trim()

--- a/lib/support-matrix/resolve.test.ts
+++ b/lib/support-matrix/resolve.test.ts
@@ -147,6 +147,25 @@ describe('resolveMatrix — name + node passthrough', () => {
   })
 })
 
+describe('resolveMatrix — nodeOmit passthrough', () => {
+  it('drops an EOL major the engines range still permits', () => {
+    const model = resolveMatrix({
+      engines: '^22.20 || ^24.12 || >=25',
+      nodeTested: '22,24',
+      nodeOmit: '25',
+    })
+    expect(model.node?.pills.map((p) => p.major)).toEqual([22, 24, 26])
+  })
+
+  it('sanitizes nodeOmit like nodeTested — junk tokens omit nothing', () => {
+    const model = resolveMatrix({
+      engines: '^22.20 || ^24.12 || >=25',
+      nodeOmit: '25garbage,junk',
+    })
+    expect(model.node?.pills.map((p) => p.major)).toContain(25)
+  })
+})
+
 // The spec's worked example — must produce exactly this shape.
 describe('resolveMatrix — lzma fixture', () => {
   const model = resolveMatrix({

--- a/lib/support-matrix/resolve.ts
+++ b/lib/support-matrix/resolve.ts
@@ -50,6 +50,7 @@ export interface MatrixQuery {
   name?: QueryValue
   engines?: QueryValue
   nodeTested?: QueryValue
+  nodeOmit?: QueryValue
 }
 
 const TIERS: Tier[] = ['tested', 'nonblocking', 'untested']
@@ -204,7 +205,12 @@ export function resolveMatrix(query: MatrixQuery = {}): MatrixModel {
 
   const enginesRaw = parseEngines(query.engines)
   const node: NodeModel | null = enginesRaw
-    ? deriveNode(enginesRaw, parseNodeTested(query.nodeTested), NODE_LATEST)
+    ? deriveNode(
+        enginesRaw,
+        parseNodeTested(query.nodeTested),
+        NODE_LATEST,
+        parseNodeTested(query.nodeOmit),
+      )
     : null
 
   const model: MatrixModel = { node, platforms, browser }

--- a/lib/support-matrix/routes.test.ts
+++ b/lib/support-matrix/routes.test.ts
@@ -104,9 +104,16 @@ describe('parseSupportMatrixQuery', () => {
     expect(query.untested).toBeUndefined()
     expect(query.omit).toBeUndefined()
     expect(query.nodeTested).toBeUndefined()
+    expect(query.nodeOmit).toBeUndefined()
     expect(query.engines).toBeUndefined()
     expect(query.name).toBeUndefined()
     expect(query.wasm).toBeUndefined()
+  })
+
+  it('parses nodeOmit → numbers with the same integer-only guard as nodeTested', () => {
+    const { query } = parseSupportMatrixQuery(get('nodeOmit=25,25garbage,26'))
+    // `25garbage` is not a whole-digit token → dropped; 25 and 26 survive.
+    expect(query.nodeOmit).toEqual([25, 26])
   })
 
   it('parses theme (dark opt-in; default light)', () => {


### PR DESCRIPTION
## What

Adds a `nodeOmit` query param to the support-matrix badge service: a comma list of Node majors to drop from the Node.js card's pills, even when the `engines` range still permits them (e.g. an EOL runtime like Node 25 under `>=25`).

- `nodeOmit=25` turns pills `22.20+ · 24.12+ · 25 · 26` into `22.20+ · 24.12+ · 26`.
- The `engines` string is still rendered **verbatim**, so the declared range is never hidden.
- Sanitized exactly like `nodeTested` (whole-digit integers only; junk dropped).

## Consistency

Omission is applied **before** coverage/gap accounting, and the headline now spans the surviving pills, so:

- an omitted major leaves **no pill and no `excluded` mention** — it vanishes from the card;
- omitting the floor or ceiling major no longer dangles the headline (previously `>=22` + `nodeOmit=26` still showed `v22 → v26` with no `26` pill; now it retracts to `v22 → v25`).

## Threaded through

`lib/support-matrix/{node,query,resolve}.ts`, `routes.test.ts`, and the `/support-matrix` URL-builder (`components/support-matrix-builder/index.tsx`).

## Tests

`vitest` — node/query/resolve/routes suites, including boundary cases (omit floor, ceiling, all-covered majors, and an already-excluded major). Full suite: **367 passing**.

## Not included

Per-query **edge caching** for `/support-matrix.{png,svg}` is out of scope here — the void-platform direct-route cache key strips the query string, so it needs a platform-side fix (the static-candidate cache key), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
