### PR TITLE
feat(support-matrix): key the edge cache on badge query params

### DIFF
--- a/void.json
+++ b/void.json
@@ -65,6 +65,32 @@
       ],
       "/*.md": ["Content-Type: text/markdown; charset=utf-8"],
       "/rss.xml": ["Content-Type: application/rss+xml; charset=utf-8"]
+    },
+    "revalidateQueryAllowlist": {
+      "/support-matrix.png": [
+        "tested",
+        "nonblocking",
+        "untested",
+        "omit",
+        "wasm",
+        "name",
+        "engines",
+        "nodeTested",
+        "nodeOmit",
+        "theme"
+      ],
+      "/support-matrix.svg": [
+        "tested",
+        "nonblocking",
+        "untested",
+        "omit",
+        "wasm",
+        "name",
+        "engines",
+        "nodeTested",
+        "nodeOmit",
+        "theme"
+      ]
     }
   },
   "inference": {


### PR DESCRIPTION
## What

Declare `revalidateQueryAllowlist` for the `/support-matrix.{png,svg}` badge routes so each query variant caches independently at the edge.

## Why

The badge renders a **different image per query** (`engines`, `nodeTested`, `nodeOmit`, `tested`, …), but dispatch's static-candidate edge cache keys only on `pathname + version`. So the first render for a given path was served to every later request regardless of query — all badge variants collapsed onto one cached image. A lzma README embedding `?…&nodeOmit=25` would get whatever image happened to warm the cache first.

## How

```
void.json  routing.revalidateQueryAllowlist
   └─ /support-matrix.png → [10 params]
   └─ /support-matrix.svg → [10 params]
        │  (config field)
        ▼  renamed at deploy → routing.queryAllowlist  (api/src/routing.ts)
        ▼  read by dispatch static-candidate cache via
           exactQueryAllowlist(routing.queryAllowlist)  (dispatch #232, deployed)
        ▼  cache key now includes the allowlisted params → per-variant caching
```

The param list is **exactly** the 10 the query parser reads (`lib/support-matrix/query.ts`): `tested, nonblocking, untested, omit, wasm, name, engines, nodeTested, nodeOmit, theme`. Any param omitted from the list would silently share a cache slot, so the list is kept in lockstep with the parser.

### Notes

- **Exact literal keys required.** void-platform #232 runs the static-candidate allowlist through `exactQueryAllowlist`, which drops any `*`/prefix-wildcard pattern (a fan-out guard, since this cache has no per-path variant cap). `/support-matrix.png` and `/support-matrix.svg` are wildcard-free, so they opt in; a `*` entry would be a silent no-op here.
- **Depends on** void-platform #232 (merged + deployed) — without it, `routing.queryAllowlist` is never read on the direct static-candidate path.
- The schema description still says "for dispatch rewrites"; the #232 change extended the same field to the static-candidate cache. Validation (`^(\/|\*$)` keys, string-array values) is unaffected.

## Verification

- JSON valid; both keys match the schema key pattern and are wildcard-free.
- Param arrays verified equal to the parser's exact set.
- Full config→cache-key chain traced hop-by-hop in the deployed void-platform (config parse → deploy manifest → `revalidateQueryAllowlist`→`queryAllowlist` rename → KV routing entry → dispatch static-candidate read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)