### PR TITLE
feat(docs): replace ASCII module-init diagram with an animated timeline

### DIFF
--- a/content/docs/concepts/module-init.cn.mdx
+++ b/content/docs/concepts/module-init.cn.mdx
@@ -11,36 +11,44 @@ NAPI-RS 提供两个模块初始化 API：`#[napi_derive::module_init]` 和 `#[n
 
 要正确使用这两个 API，关键是理解各自何时执行：
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                    Node.js loads .node file                     │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  1. #[napi_derive::module_init] runs                            │
-│     (via ctor - runs at dynamic library load time)              │
-│     Runs once for this native library load                     │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  2. napi_register_module_v1 called by Node.js                   │
-│     - Registers all #[napi] exports (functions, classes, etc.)  │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  3. #[napi(module_exports)] runs                                │
-│     Receives the exports object, can customize it               │
-│     Runs ONCE per Node.js thread/context                        │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  4. Module is ready for use in JavaScript                       │
-└─────────────────────────────────────────────────────────────────┘
-```
+<figure class="mi-flow" aria-label="模块初始化时间线">
+  <ol class="mi-flow-list">
+    <li class="mi-step mi-step--state">
+      <span class="mi-node mi-node--file" aria-hidden="true">⬇</span>
+      <div class="mi-card">
+        <p class="mi-card-title">Node.js 加载 <code>.node</code> 文件</p>
+      </div>
+    </li>
+    <li class="mi-step">
+      <span class="mi-node" aria-hidden="true">1</span>
+      <div class="mi-card">
+        <p class="mi-card-title"><code>#[napi_derive::module_init]</code> 运行</p>
+        <p class="mi-card-sub">通过 <code>ctor</code> —— 在动态库加载时执行 · 每次原生库加载仅一次</p>
+      </div>
+    </li>
+    <li class="mi-step">
+      <span class="mi-node" aria-hidden="true">2</span>
+      <div class="mi-card">
+        <p class="mi-card-title">Node.js 调用 <code>napi_register_module_v1</code></p>
+        <p class="mi-card-sub">注册所有 <code>#[napi]</code> 导出 —— 函数、类等</p>
+      </div>
+    </li>
+    <li class="mi-step">
+      <span class="mi-node" aria-hidden="true">3</span>
+      <div class="mi-card">
+        <p class="mi-card-title"><code>#[napi(module_exports)]</code> 运行</p>
+        <p class="mi-card-sub">接收 <code>exports</code> 对象并可自定义 · 每个 Node.js 线程/上下文仅一次</p>
+      </div>
+    </li>
+    <li class="mi-step mi-step--final">
+      <span class="mi-node mi-node--done" aria-hidden="true">✓</span>
+      <div class="mi-card">
+        <p class="mi-card-title">模块就绪，可在 JavaScript 中使用</p>
+      </div>
+    </li>
+  </ol>
+  <span class="mi-pulse" aria-hidden="true"></span>
+</figure>
 
 ## `#[napi_derive::module_init]`
 

--- a/content/docs/concepts/module-init.en.mdx
+++ b/content/docs/concepts/module-init.en.mdx
@@ -11,36 +11,44 @@ NAPI-RS provides two APIs for module initialization: `#[napi_derive::module_init
 
 Understanding when each API executes is crucial for using them correctly:
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                    Node.js loads .node file                     │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  1. #[napi_derive::module_init] runs                            │
-│     (via ctor - runs at dynamic library load time)              │
-│     Runs once for this native library load                     │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  2. napi_register_module_v1 called by Node.js                   │
-│     - Registers all #[napi] exports (functions, classes, etc.)  │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  3. #[napi(module_exports)] runs                                │
-│     Receives the exports object, can customize it               │
-│     Runs ONCE per Node.js thread/context                        │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  4. Module is ready for use in JavaScript                       │
-└─────────────────────────────────────────────────────────────────┘
-```
+<figure class="mi-flow" aria-label="Module initialization timeline">
+  <ol class="mi-flow-list">
+    <li class="mi-step mi-step--state">
+      <span class="mi-node mi-node--file" aria-hidden="true">⬇</span>
+      <div class="mi-card">
+        <p class="mi-card-title">Node.js loads the <code>.node</code> file</p>
+      </div>
+    </li>
+    <li class="mi-step">
+      <span class="mi-node" aria-hidden="true">1</span>
+      <div class="mi-card">
+        <p class="mi-card-title"><code>#[napi_derive::module_init]</code> runs</p>
+        <p class="mi-card-sub">via <code>ctor</code> — at dynamic library load time · once per native library load</p>
+      </div>
+    </li>
+    <li class="mi-step">
+      <span class="mi-node" aria-hidden="true">2</span>
+      <div class="mi-card">
+        <p class="mi-card-title"><code>napi_register_module_v1</code> called by Node.js</p>
+        <p class="mi-card-sub">Registers all <code>#[napi]</code> exports — functions, classes, and more</p>
+      </div>
+    </li>
+    <li class="mi-step">
+      <span class="mi-node" aria-hidden="true">3</span>
+      <div class="mi-card">
+        <p class="mi-card-title"><code>#[napi(module_exports)]</code> runs</p>
+        <p class="mi-card-sub">Receives the <code>exports</code> object and can customize it · once per Node.js thread/context</p>
+      </div>
+    </li>
+    <li class="mi-step mi-step--final">
+      <span class="mi-node mi-node--done" aria-hidden="true">✓</span>
+      <div class="mi-card">
+        <p class="mi-card-title">Module is ready for use in JavaScript</p>
+      </div>
+    </li>
+  </ol>
+  <span class="mi-pulse" aria-hidden="true"></span>
+</figure>
 
 ## `#[napi_derive::module_init]`
 

--- a/content/docs/concepts/module-init.pt-BR.mdx
+++ b/content/docs/concepts/module-init.pt-BR.mdx
@@ -14,36 +14,44 @@ diferentes.
 
 Entender quando cada API executa é fundamental para usá-las corretamente:
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                 Node.js carrega o arquivo .node                │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  1. #[napi_derive::module_init] executa                        │
-│     (via ctor - executa no carregamento da biblioteca)         │
-│     Executa uma vez para este carregamento da biblioteca       │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  2. napi_register_module_v1 é chamado pelo Node.js             │
-│     - Registra todos os exports #[napi] (funções, classes etc.)│
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  3. #[napi(module_exports)] executa                            │
-│     Recebe o objeto exports e pode personalizá-lo              │
-│     Executa UMA VEZ por thread/contexto do Node.js             │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  4. O módulo está pronto para uso em JavaScript                │
-└─────────────────────────────────────────────────────────────────┘
-```
+<figure class="mi-flow" aria-label="Linha do tempo de inicialização do módulo">
+  <ol class="mi-flow-list">
+    <li class="mi-step mi-step--state">
+      <span class="mi-node mi-node--file" aria-hidden="true">⬇</span>
+      <div class="mi-card">
+        <p class="mi-card-title">Node.js carrega o arquivo <code>.node</code></p>
+      </div>
+    </li>
+    <li class="mi-step">
+      <span class="mi-node" aria-hidden="true">1</span>
+      <div class="mi-card">
+        <p class="mi-card-title"><code>#[napi_derive::module_init]</code> executa</p>
+        <p class="mi-card-sub">via <code>ctor</code> — no carregamento da biblioteca dinâmica · uma vez por carregamento da biblioteca nativa</p>
+      </div>
+    </li>
+    <li class="mi-step">
+      <span class="mi-node" aria-hidden="true">2</span>
+      <div class="mi-card">
+        <p class="mi-card-title"><code>napi_register_module_v1</code> é chamado pelo Node.js</p>
+        <p class="mi-card-sub">Registra todos os exports <code>#[napi]</code> — funções, classes e mais</p>
+      </div>
+    </li>
+    <li class="mi-step">
+      <span class="mi-node" aria-hidden="true">3</span>
+      <div class="mi-card">
+        <p class="mi-card-title"><code>#[napi(module_exports)]</code> executa</p>
+        <p class="mi-card-sub">Recebe o objeto <code>exports</code> e pode personalizá-lo · uma vez por thread/contexto do Node.js</p>
+      </div>
+    </li>
+    <li class="mi-step mi-step--final">
+      <span class="mi-node mi-node--done" aria-hidden="true">✓</span>
+      <div class="mi-card">
+        <p class="mi-card-title">O módulo está pronto para uso em JavaScript</p>
+      </div>
+    </li>
+  </ol>
+  <span class="mi-pulse" aria-hidden="true"></span>
+</figure>
 
 ## `#[napi_derive::module_init]`
 

--- a/lib/docs/lastmod.gen.json
+++ b/lib/docs/lastmod.gen.json
@@ -46,7 +46,7 @@
       ]
     },
     "docs/cli/create-npm-dirs": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -55,7 +55,7 @@
       ]
     },
     "docs/cli/napi-config": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -91,7 +91,7 @@
       ]
     },
     "docs/cli/rename": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -100,7 +100,7 @@
       ]
     },
     "docs/cli/universalize": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -109,7 +109,7 @@
       ]
     },
     "docs/cli/version": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -118,7 +118,7 @@
       ]
     },
     "docs/concepts/async-fn": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -127,7 +127,7 @@
       ]
     },
     "docs/concepts/async-runtime": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -172,7 +172,7 @@
       ]
     },
     "docs/concepts/env": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -190,7 +190,7 @@
       ]
     },
     "docs/concepts/exports": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -208,7 +208,7 @@
       ]
     },
     "docs/concepts/function": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -217,7 +217,7 @@
       ]
     },
     "docs/concepts/inject-env": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -262,7 +262,7 @@
       ]
     },
     "docs/concepts/napi-attributes": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -280,7 +280,7 @@
       ]
     },
     "docs/concepts/promise": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -298,7 +298,7 @@
       ]
     },
     "docs/concepts/streams": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -307,7 +307,7 @@
       ]
     },
     "docs/concepts/threadsafe-function": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -316,7 +316,7 @@
       ]
     },
     "docs/concepts/type-conversions": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -334,7 +334,7 @@
       ]
     },
     "docs/concepts/types-overwrite": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -352,7 +352,7 @@
       ]
     },
     "docs/concepts/values": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -361,7 +361,7 @@
       ]
     },
     "docs/concepts/webassembly": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -388,7 +388,7 @@
       ]
     },
     "docs/deep-dive/native-module": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -406,7 +406,7 @@
       ]
     },
     "docs/introduction/getting-started": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -424,7 +424,7 @@
       ]
     },
     "docs/introduction/simple-package": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -442,7 +442,7 @@
       ]
     },
     "docs/more/examples": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -496,7 +496,7 @@
       ]
     },
     "docs/more/v2-v3-migration-guide": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -606,7 +606,7 @@
       ]
     },
     "docs/concepts/async-fn": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -615,7 +615,7 @@
       ]
     },
     "docs/concepts/async-task": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -669,7 +669,7 @@
       ]
     },
     "docs/concepts/exports": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -687,7 +687,7 @@
       ]
     },
     "docs/concepts/function": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -741,7 +741,7 @@
       ]
     },
     "docs/concepts/napi-attributes": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -759,7 +759,7 @@
       ]
     },
     "docs/concepts/promise": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -831,7 +831,7 @@
       ]
     },
     "docs/concepts/webassembly": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -876,7 +876,7 @@
       ]
     },
     "docs/introduction/getting-started": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -894,7 +894,7 @@
       ]
     },
     "docs/introduction/simple-package": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -1058,7 +1058,7 @@
       ]
     },
     "docs/concepts/async-fn": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -1067,7 +1067,7 @@
       ]
     },
     "docs/concepts/async-task": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -1121,7 +1121,7 @@
       ]
     },
     "docs/concepts/exports": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -1139,7 +1139,7 @@
       ]
     },
     "docs/concepts/function": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -1193,7 +1193,7 @@
       ]
     },
     "docs/concepts/napi-attributes": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -1211,7 +1211,7 @@
       ]
     },
     "docs/concepts/promise": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -1283,7 +1283,7 @@
       ]
     },
     "docs/concepts/webassembly": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -1328,7 +1328,7 @@
       ]
     },
     "docs/introduction/getting-started": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -1346,7 +1346,7 @@
       ]
     },
     "docs/introduction/simple-package": {
-      "lastmod": "2026-07-29T17:51:01+08:00",
+      "lastmod": "2026-07-29T23:43:39+08:00",
       "contributors": [
         {
           "name": "LongYinan",

--- a/pages/cn/docs/concepts/module-init.md
+++ b/pages/cn/docs/concepts/module-init.md
@@ -11,36 +11,44 @@ NAPI-RS 提供两个模块初始化 API：`#[napi_derive::module_init]` 和 `#[n
 
 要正确使用这两个 API，关键是理解各自何时执行：
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                    Node.js loads .node file                     │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  1. #[napi_derive::module_init] runs                            │
-│     (via ctor - runs at dynamic library load time)              │
-│     Runs once for this native library load                     │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  2. napi_register_module_v1 called by Node.js                   │
-│     - Registers all #[napi] exports (functions, classes, etc.)  │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  3. #[napi(module_exports)] runs                                │
-│     Receives the exports object, can customize it               │
-│     Runs ONCE per Node.js thread/context                        │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  4. Module is ready for use in JavaScript                       │
-└─────────────────────────────────────────────────────────────────┘
-```
+<figure class="mi-flow" aria-label="模块初始化时间线">
+  <ol class="mi-flow-list">
+    <li class="mi-step mi-step--state">
+      <span class="mi-node mi-node--file" aria-hidden="true">⬇</span>
+      <div class="mi-card">
+        <p class="mi-card-title">Node.js 加载 <code>.node</code> 文件</p>
+      </div>
+    </li>
+    <li class="mi-step">
+      <span class="mi-node" aria-hidden="true">1</span>
+      <div class="mi-card">
+        <p class="mi-card-title"><code>#[napi_derive::module_init]</code> 运行</p>
+        <p class="mi-card-sub">通过 <code>ctor</code> —— 在动态库加载时执行 · 每次原生库加载仅一次</p>
+      </div>
+    </li>
+    <li class="mi-step">
+      <span class="mi-node" aria-hidden="true">2</span>
+      <div class="mi-card">
+        <p class="mi-card-title">Node.js 调用 <code>napi_register_module_v1</code></p>
+        <p class="mi-card-sub">注册所有 <code>#[napi]</code> 导出 —— 函数、类等</p>
+      </div>
+    </li>
+    <li class="mi-step">
+      <span class="mi-node" aria-hidden="true">3</span>
+      <div class="mi-card">
+        <p class="mi-card-title"><code>#[napi(module_exports)]</code> 运行</p>
+        <p class="mi-card-sub">接收 <code>exports</code> 对象并可自定义 · 每个 Node.js 线程/上下文仅一次</p>
+      </div>
+    </li>
+    <li class="mi-step mi-step--final">
+      <span class="mi-node mi-node--done" aria-hidden="true">✓</span>
+      <div class="mi-card">
+        <p class="mi-card-title">模块就绪，可在 JavaScript 中使用</p>
+      </div>
+    </li>
+  </ol>
+  <span class="mi-pulse" aria-hidden="true"></span>
+</figure>
 
 ## `#[napi_derive::module_init]`
 

--- a/pages/en/docs/concepts/module-init.md
+++ b/pages/en/docs/concepts/module-init.md
@@ -11,36 +11,44 @@ NAPI-RS provides two APIs for module initialization: `#[napi_derive::module_init
 
 Understanding when each API executes is crucial for using them correctly:
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                    Node.js loads .node file                     │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  1. #[napi_derive::module_init] runs                            │
-│     (via ctor - runs at dynamic library load time)              │
-│     Runs once for this native library load                     │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  2. napi_register_module_v1 called by Node.js                   │
-│     - Registers all #[napi] exports (functions, classes, etc.)  │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  3. #[napi(module_exports)] runs                                │
-│     Receives the exports object, can customize it               │
-│     Runs ONCE per Node.js thread/context                        │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  4. Module is ready for use in JavaScript                       │
-└─────────────────────────────────────────────────────────────────┘
-```
+<figure class="mi-flow" aria-label="Module initialization timeline">
+  <ol class="mi-flow-list">
+    <li class="mi-step mi-step--state">
+      <span class="mi-node mi-node--file" aria-hidden="true">⬇</span>
+      <div class="mi-card">
+        <p class="mi-card-title">Node.js loads the <code>.node</code> file</p>
+      </div>
+    </li>
+    <li class="mi-step">
+      <span class="mi-node" aria-hidden="true">1</span>
+      <div class="mi-card">
+        <p class="mi-card-title"><code>#[napi_derive::module_init]</code> runs</p>
+        <p class="mi-card-sub">via <code>ctor</code> — at dynamic library load time · once per native library load</p>
+      </div>
+    </li>
+    <li class="mi-step">
+      <span class="mi-node" aria-hidden="true">2</span>
+      <div class="mi-card">
+        <p class="mi-card-title"><code>napi_register_module_v1</code> called by Node.js</p>
+        <p class="mi-card-sub">Registers all <code>#[napi]</code> exports — functions, classes, and more</p>
+      </div>
+    </li>
+    <li class="mi-step">
+      <span class="mi-node" aria-hidden="true">3</span>
+      <div class="mi-card">
+        <p class="mi-card-title"><code>#[napi(module_exports)]</code> runs</p>
+        <p class="mi-card-sub">Receives the <code>exports</code> object and can customize it · once per Node.js thread/context</p>
+      </div>
+    </li>
+    <li class="mi-step mi-step--final">
+      <span class="mi-node mi-node--done" aria-hidden="true">✓</span>
+      <div class="mi-card">
+        <p class="mi-card-title">Module is ready for use in JavaScript</p>
+      </div>
+    </li>
+  </ol>
+  <span class="mi-pulse" aria-hidden="true"></span>
+</figure>
 
 ## `#[napi_derive::module_init]`
 

--- a/pages/pt-BR/docs/concepts/module-init.md
+++ b/pages/pt-BR/docs/concepts/module-init.md
@@ -14,36 +14,44 @@ diferentes.
 
 Entender quando cada API executa é fundamental para usá-las corretamente:
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                 Node.js carrega o arquivo .node                │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  1. #[napi_derive::module_init] executa                        │
-│     (via ctor - executa no carregamento da biblioteca)         │
-│     Executa uma vez para este carregamento da biblioteca       │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  2. napi_register_module_v1 é chamado pelo Node.js             │
-│     - Registra todos os exports #[napi] (funções, classes etc.)│
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  3. #[napi(module_exports)] executa                            │
-│     Recebe o objeto exports e pode personalizá-lo              │
-│     Executa UMA VEZ por thread/contexto do Node.js             │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  4. O módulo está pronto para uso em JavaScript                │
-└─────────────────────────────────────────────────────────────────┘
-```
+<figure class="mi-flow" aria-label="Linha do tempo de inicialização do módulo">
+  <ol class="mi-flow-list">
+    <li class="mi-step mi-step--state">
+      <span class="mi-node mi-node--file" aria-hidden="true">⬇</span>
+      <div class="mi-card">
+        <p class="mi-card-title">Node.js carrega o arquivo <code>.node</code></p>
+      </div>
+    </li>
+    <li class="mi-step">
+      <span class="mi-node" aria-hidden="true">1</span>
+      <div class="mi-card">
+        <p class="mi-card-title"><code>#[napi_derive::module_init]</code> executa</p>
+        <p class="mi-card-sub">via <code>ctor</code> — no carregamento da biblioteca dinâmica · uma vez por carregamento da biblioteca nativa</p>
+      </div>
+    </li>
+    <li class="mi-step">
+      <span class="mi-node" aria-hidden="true">2</span>
+      <div class="mi-card">
+        <p class="mi-card-title"><code>napi_register_module_v1</code> é chamado pelo Node.js</p>
+        <p class="mi-card-sub">Registra todos os exports <code>#[napi]</code> — funções, classes e mais</p>
+      </div>
+    </li>
+    <li class="mi-step">
+      <span class="mi-node" aria-hidden="true">3</span>
+      <div class="mi-card">
+        <p class="mi-card-title"><code>#[napi(module_exports)]</code> executa</p>
+        <p class="mi-card-sub">Recebe o objeto <code>exports</code> e pode personalizá-lo · uma vez por thread/contexto do Node.js</p>
+      </div>
+    </li>
+    <li class="mi-step mi-step--final">
+      <span class="mi-node mi-node--done" aria-hidden="true">✓</span>
+      <div class="mi-card">
+        <p class="mi-card-title">O módulo está pronto para uso em JavaScript</p>
+      </div>
+    </li>
+  </ol>
+  <span class="mi-pulse" aria-hidden="true"></span>
+</figure>
 
 ## `#[napi_derive::module_init]`
 

--- a/pages/theme.css
+++ b/pages/theme.css
@@ -592,3 +592,200 @@
 .pm-tabs:not(:has(.pm-input:checked)) .pm-panel[data-pm-default] {
   display: block;
 }
+
+/* ── Module-init execution timeline (concepts/module-init) ──────────────────
+ *
+ * Replaces the old ASCII flow diagram with an animated vertical timeline:
+ * a gradient spine with numbered nodes, cards per step, a glow dot that
+ * travels down the spine, and a scroll-driven rise-in per step (progressive
+ * enhancement — content is fully visible without it, zero JS). Theme-aware
+ * via the site's tokens; honors prefers-reduced-motion.
+ */
+
+.mi-flow {
+  position: relative;
+  margin-top: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+/* Scoped under .void-md so it beats the prose stylesheet's ol rules — the
+ * custom node markers replace list numbering entirely. */
+.void-md .mi-flow-list,
+.mi-flow-list {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+  margin: 0;
+  padding: 0 0 0 2.75rem;
+  list-style: none;
+}
+
+.void-md .mi-flow-list .mi-step::marker {
+  content: none;
+}
+
+/* The spine: a soft gradient line that "charges" from neutral to brand
+ * orange to success green, mirroring the flow toward the ready state. */
+.mi-flow-list::before {
+  content: '';
+  position: absolute;
+  left: 0.875rem;
+  top: 0.875rem;
+  bottom: 0.875rem;
+  width: 2px;
+  border-radius: 2px;
+  background: linear-gradient(
+    to bottom,
+    var(--border) 0%,
+    var(--theme) 55%,
+    #22c55e 100%
+  );
+  opacity: 0.55;
+}
+
+.mi-step {
+  position: relative;
+}
+
+/* Numbered node on the spine. */
+.mi-node {
+  position: absolute;
+  left: -2.75rem;
+  top: 50%;
+  translate: 0 -50%;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 9999px;
+  border: 2px solid var(--border);
+  background: var(--background);
+  color: var(--muted-foreground);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+/* Step nodes glow brand orange; the terminal "ready" node goes green. */
+.mi-step:not(.mi-step--state):not(.mi-step--final) .mi-node {
+  border-color: var(--theme);
+  color: var(--theme);
+  box-shadow: 0 0 0 4px hsl(var(--theme-hsl) / 0.12);
+}
+
+.mi-node--done {
+  border-color: #22c55e;
+  color: #22c55e;
+  box-shadow: 0 0 0 4px rgb(34 197 94 / 0.14);
+}
+
+.mi-card {
+  border: 1px solid var(--border);
+  border-radius: 0.625rem;
+  background: var(--muted);
+  padding: 0.7rem 1rem;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+}
+
+.mi-card:hover {
+  transform: translateX(2px);
+  border-color: hsl(var(--theme-hsl) / 0.5);
+  box-shadow: 0 4px 16px -6px hsl(var(--theme-hsl) / 0.25);
+}
+
+.mi-step--final .mi-card {
+  border-color: rgb(34 197 94 / 0.45);
+  background: rgb(34 197 94 / 0.07);
+}
+
+.mi-step--final .mi-card:hover {
+  border-color: rgb(34 197 94 / 0.7);
+  box-shadow: 0 4px 16px -6px rgb(34 197 94 / 0.3);
+}
+
+.mi-card-title {
+  margin: 0;
+  font-size: 0.925rem;
+  font-weight: 600;
+  line-height: 1.5;
+}
+
+.mi-card-sub {
+  margin: 0.2rem 0 0;
+  font-size: 0.8125rem;
+  line-height: 1.55;
+  color: var(--muted-foreground);
+}
+
+/* The glow dot traveling down the spine — the "execution" moving through
+ * the timeline. Reflow-based top animation is fine for one 8px element. */
+.mi-pulse {
+  position: absolute;
+  left: calc(0.875rem - 3px);
+  top: 0.875rem;
+  width: 8px;
+  height: 8px;
+  border-radius: 9999px;
+  background: var(--theme);
+  box-shadow:
+    0 0 10px 2px hsl(var(--theme-hsl) / 0.8),
+    0 0 22px 6px hsl(var(--theme-hsl) / 0.35);
+  animation: mi-pulse-travel 4.5s ease-in-out infinite;
+}
+
+@keyframes mi-pulse-travel {
+  0% {
+    top: 0.875rem;
+    opacity: 0;
+  }
+  12% {
+    opacity: 1;
+  }
+  85% {
+    opacity: 1;
+  }
+  100% {
+    top: calc(100% - 1.75rem);
+    opacity: 0;
+  }
+}
+
+/* Scroll-driven reveal: each step rises in as it enters the viewport.
+ * Progressive enhancement only — without view() support or JS the steps are
+ * simply visible, identical to a static diagram. */
+@supports (animation-timeline: view()) {
+  @media (prefers-reduced-motion: no-preference) {
+    .mi-step {
+      animation: mi-rise ease-out both;
+      animation-timeline: view();
+      animation-range: entry 0% entry 60%;
+    }
+
+    @keyframes mi-rise {
+      from {
+        opacity: 0;
+        transform: translateY(14px);
+      }
+      to {
+        opacity: 1;
+        transform: none;
+      }
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mi-pulse {
+    display: none;
+  }
+  .mi-card,
+  .mi-card:hover {
+    transition: none;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary

The module-init execution-order diagram was a monospace ASCII box drawing. This replaces it (en + cn + pt-BR) with a pure HTML/CSS animated vertical timeline — no JS, no islands.

### What it does
- **Gradient spine** (neutral → brand orange → success green) with numbered nodes and a green ✓ terminal node
- **Glow dot traveling down the spine** — the "execution" moving through the timeline
- **Scroll-driven rise-in** per step via `animation-timeline: view()` — progressive enhancement only; the diagram is fully visible without it
- Cards with hover lift + glow; real `<ol>` semantics for screen readers
- Theme-aware via site tokens; honors `prefers-reduced-motion`

### Also
- The cn page gets proper Chinese step text (its ASCII block was untranslated English); pt-BR text carried over and polished
- Prose `ol` numbering suppressed with `.void-md`-scoped specificity

### Verification
- 433/433 tests, `yarn build` green
- Rendered markup + visuals confirmed via headless-Chrome screenshots (dark mode; tokens make it theme-safe for light)

Screenshots (dev server, dark mode — the orange glow on the spine is the traveling pulse captured mid-animation): see branch artifacts / local verification.