### PR TITLE
feat(sponsors): point TestMu AI at their own site

### DIFF
--- a/lib/docs/lastmod.gen.json
+++ b/lib/docs/lastmod.gen.json
@@ -82,7 +82,7 @@
       ]
     },
     "docs/cli/programmatic-api": {
-      "lastmod": "2026-08-03T11:50:30+08:00",
+      "lastmod": "2026-08-07T09:52:27+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -570,7 +570,7 @@
       ]
     },
     "docs/cli/programmatic-api": {
-      "lastmod": "2026-08-03T11:50:30+08:00",
+      "lastmod": "2026-08-07T09:52:27+08:00",
       "contributors": [
         {
           "name": "LongYinan",
@@ -1022,7 +1022,7 @@
       ]
     },
     "docs/cli/programmatic-api": {
-      "lastmod": "2026-08-03T11:50:30+08:00",
+      "lastmod": "2026-08-07T09:52:27+08:00",
       "contributors": [
         {
           "name": "LongYinan",

--- a/lib/landing/sponsors.test.ts
+++ b/lib/landing/sponsors.test.ts
@@ -62,7 +62,8 @@ describe('wash', () => {
     expect(washed.sliver[0].url).toBe('https://github.com/nrwl')
     expect(washed.backers[0].url).toBe('https://github.com/octocat')
     // Even when the upstream item carries a websiteUrl, the locked decision is
-    // to always point at the github profile.
+    // to ignore it. A sponsor link only ever moves off the github profile via
+    // the curated LINK_OVERRIDES map, never from payload data.
     const withWebsite = wash({
       gold: [
         {
@@ -76,6 +77,45 @@ describe('wash', () => {
       ],
     })
     expect(withWebsite.gold[0].url).toBe('https://github.com/workleap')
+  })
+
+  // Sponsors can ask for their card to link to their own site instead of their
+  // GitHub profile. The override is keyed by exact login casing.
+  it('applies LINK_OVERRIDES for sponsors who requested a custom link', () => {
+    const washed = wash({
+      sliver: [
+        {
+          login: 'LambdaTest-Inc',
+          name: 'TestMu AI Open Source Office (Formerly LambdaTest)',
+          avatarUrl: 'https://avatars.githubusercontent.com/u/171592363?v=4',
+        },
+      ],
+    })
+    expect(washed.sliver[0].url).toBe(
+      'https://www.testmuai.com/?utm_medium=sponsor&utm_source=napi-rs',
+    )
+    // The rest of the shape is untouched by the override.
+    expect(washed.sliver[0].name).toBe(
+      'TestMu AI Open Source Office (Formerly LambdaTest)',
+    )
+    expect(washed.sliver[0].img).toBe(
+      'https://avatars.githubusercontent.com/u/171592363?v=4',
+    )
+  })
+
+  it('leaves non-overridden logins on their github profile', () => {
+    // Guards against an override map that accidentally matches everything.
+    const washed = wash({
+      sliver: [{ login: 'nrwl', name: 'Nx', avatarUrl: 'x' }],
+    })
+    expect(washed.sliver[0].url).toBe('https://github.com/nrwl')
+  })
+
+  it('matches the override on exact login casing only', () => {
+    const washed = wash({
+      sliver: [{ login: 'lambdatest-inc', name: 'lowercased', avatarUrl: 'x' }],
+    })
+    expect(washed.sliver[0].url).toBe('https://github.com/lambdatest-inc')
   })
 
   it('returns all-empty tiers for an empty object', () => {

--- a/lib/landing/sponsors.ts
+++ b/lib/landing/sponsors.ts
@@ -8,7 +8,12 @@
 // backers (the `sliver` misspelling is intentional and MUST be preserved —
 // `mapSponsors` reads `sponsors['sliver']`). Each raw item is
 // `{ login, name, avatarUrl }`; the sponsor link points at the GitHub profile
-// (`https://github.com/<login>`).
+// (`https://github.com/<login>`) unless the login appears in LINK_OVERRIDES.
+//
+// This is the ONLY place a sponsor URL is constructed — the landing wall
+// (`components/landing/sponsors.tsx`) and the `/sponsors.{svg,png}` cards
+// (`lib/sponsors-image/card.ts`) both consume the washed `url`, and `login` is
+// dropped here, so an override has to live at this stage.
 
 export interface RawSponsor {
   login: string
@@ -40,6 +45,20 @@ const TIERS = [
   'backers',
 ] as const
 
+// Sponsors who asked for their card to point somewhere other than their GitHub
+// profile. Keyed by the exact GitHub login casing, matching the convention of
+// `EXCLUDED_LOGINS` in load-sponsors.ts.
+//
+// Note the snapshot in KV stores WASHED data and the SVG/PNG cards bake the href
+// into their bytes, so editing this map does nothing until a sponsors refresh
+// runs — redeliver the GitHub sponsors webhook, or wait for the daily cron.
+const LINK_OVERRIDES: Record<string, string> = {
+  // Requested by the sponsor 2026-08-06; "TestMu AI Open Source Office
+  // (Formerly LambdaTest)".
+  'LambdaTest-Inc':
+    'https://www.testmuai.com/?utm_medium=sponsor&utm_source=napi-rs',
+}
+
 function washTier(items: RawSponsor[] | undefined): WashedSponsor[] {
   if (!Array.isArray(items)) {
     return []
@@ -47,7 +66,7 @@ function washTier(items: RawSponsor[] | undefined): WashedSponsor[] {
   return items.map((item) => ({
     name: item.name,
     img: item.avatarUrl,
-    url: `https://github.com/${item.login}`,
+    url: LINK_OVERRIDES[item.login] ?? `https://github.com/${item.login}`,
   }))
 }
 


### PR DESCRIPTION
TestMu AI (GitHub login `LambdaTest-Inc`, formerly LambdaTest — $100/mo, `sliver` tier) [emailed](mailto:) asking for their sponsor card to link to their own site with UTM parameters instead of their GitHub profile.

## The change

```
GitHub Sponsors API → RawSponsor{login, name, avatarUrl}
                              │
                    wash() ── lib/landing/sponsors.ts   ← only place `url` is built
                              │                            (`login` is dropped here)
                    ┌─────────┴─────────┐
              landing wall        /sponsors.{svg,png}
```

`wash()` is the single URL construction site, and it discards `login`, so the override has to live at that stage — anything downstream would have to reverse-engineer the login out of a URL string. One map covers both consumers.

Keyed on exact login casing, matching the `EXCLUDED_LOGINS` convention in `load-sponsors.ts`.

## ⚠️ This does not take effect on merge

The KV snapshot stores **washed** data (`store.ts:161`) and the SVG/PNG cards **bake the href into their bytes** (`refresh.ts:107`). Both read paths hit that cache, not `wash()`.

| trigger | latency |
|---|---|
| redeliver a `sponsorship` webhook from the napi-rs sponsors dashboard | ~30s, then 0–10 min for the CDN |
| do nothing — daily 05:00 UTC cron | ≤24 h |

Note the cold-miss path on `/sponsors.svg` **cannot self-heal**: `routes/sponsors.svg.ts:74` re-publishes the stale KV data it just read, so clearing R2 alone would re-bake the old URL.

## Verified locally

Against the real Sponsors API, both surfaces render the override and no `github.com/LambdaTest-Inc` link remains:

```
$ curl -s localhost:5173/ | grep -o 'href="[^"]*testmuai[^"]*"'
href="https://www.testmuai.com/?utm_medium=sponsor&amp;utm_source=napi-rs"

$ curl -s localhost:5173/sponsors.svg | grep -c 'github.com/LambdaTest-Inc'
0
```

The `&` correctly becomes `&amp;` through `escapeXmlAttr` and decodes back with both UTM params intact.

Tests: override applies, non-overridden logins are untouched, and a lowercased login does **not** match. Full suite green (909 passed).

## Not covered by this PR

Two parts of the sponsor's request are out of scope here:

1. **Their README link.** They asked for the link "in the GitHub README" too. README `![]()` embeds render SVG in the browser's secure static mode where **hyperlinks are inert** — `card.ts:87` already documents this. That needs an explicit markdown link in `napi-rs/napi-rs`, not a change here.
2. **Their logo.** They attached a 513×80 wordmark, but both sponsor surfaces render circular avatars (`border-radius: 50%`, `borderRadius: size / 2`). Their current GitHub avatar is already this logo's mark, correctly framed — so no change was needed. A local override would also have to be PNG/JPEG/GIF: `avatars.ts:71` rejects SVG and **silently drops the sponsor from the card**.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
